### PR TITLE
Add entity_health connector for subsystem health monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
           docker run --rm keelson "n2k-cli --help"
           # Platform connector
           docker run --rm keelson "platform-geometry2keelson --help"
+          # Entity health connector
+          docker run --rm keelson "entity_health2keelson --help"
 
       - name: Smoke test additional tools
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build*
 /sdks/python/build*
+/connectors/*/build*
+/connectors/*/*.egg-info
 /sdks/js/dist*
 /.vscode
 /cpm_modules

--- a/conftest.py
+++ b/conftest.py
@@ -49,6 +49,7 @@ BINARY_NAME_MAP = {
     "rtcm2keelson": "rtcm2keelson.py",
     "keelson2rtcm": "keelson2rtcm.py",
     "ntrip-cli": "ntrip-cli.py",
+    "entity_health2keelson": "entity_health2keelson.py",
 }
 
 

--- a/connectors/entity_health/README.md
+++ b/connectors/entity_health/README.md
@@ -33,7 +33,7 @@ Each entry in `expectations` defines one monitored subsystem:
 
 | Field                | Description                                                        |
 |----------------------|--------------------------------------------------------------------|
-| `name`               | Subsystem name emitted in `SourceHealth.name`                      |
+| `name`               | Subject name emitted in `SubjectHealth.name`                       |
 | `key_expr`           | Zenoh key expression to subscribe to (supports `*` / `**`)         |
 | `inactive_after_s`   | Silence longer than this → INACTIVE (default 10s)                  |
 | `window_s`           | Sliding window over which the publication rate is measured (default 10s) |
@@ -142,10 +142,12 @@ Valid `level` names: `NOMINAL`, `DEGRADED`, `CRITICAL`, `INACTIVE`
 
 ### Combining rate and content checks
 
-For each subsystem, the evaluator takes the **worst** level produced by
-the rate check and every content rule. The `SourceHealth.detail`
-string lists every non-nominal contributor. The overall
-`EntityHealth.level` is then the worst across all subsystems.
+For each subject, the evaluator emits one `CheckResult` per check that
+ran (the standard `activity` and `publication_rate` checks plus one per
+configured content rule), and `SubjectHealth.level` is the **worst**
+level across them. The per-check explanation lives on
+`SubjectHealth.checks[i].detail`. The overall `EntityHealth.level` is
+the worst across all subjects.
 
 ### Health levels
 

--- a/connectors/entity_health/README.md
+++ b/connectors/entity_health/README.md
@@ -1,0 +1,252 @@
+# entity_health connector
+
+Subscribes to a configurable set of Zenoh key-expressions, measures the
+publication rate and validates payload content against declarative
+expectations, and publishes a `keelson.EntityHealth` message on the
+`entity_health` subject.
+
+The active set of expectations can be replaced at runtime via the
+`Configurable` RPC interface (`get_config` / `set_config`).
+
+## Usage
+
+```bash
+entity_health2keelson \
+  --realm test-realm \
+  --entity-id test-vessel \
+  --source-id health \
+  --config example-config.json
+```
+
+## Configuration
+
+See [`example-config.json`](example-config.json) for a full example.
+
+```json
+{
+  "publish_rate_hz": 1.0,
+  "expectations": [ ... ]
+}
+```
+
+Each entry in `expectations` defines one monitored subsystem:
+
+| Field                | Description                                                        |
+|----------------------|--------------------------------------------------------------------|
+| `name`               | Subsystem name emitted in `SubsystemHealth.name`                   |
+| `key_expr`           | Zenoh key expression to subscribe to (supports `*` / `**`)         |
+| `inactive_after_s`   | Silence longer than this → INACTIVE (default 10s)                  |
+| `window_s`           | Sliding window over which the publication rate is measured (default 10s) |
+| `publication_rate_hz`         | Tiered bands applied to the observed publication rate (see below)  |
+| `publication_rate_default_level` | Level used when the observed rate matches no band (default CRITICAL) |
+| `require_liveliness` | If `true` (default), a missing Zenoh liveliness token → UNKNOWN    |
+| `content_rules`      | List of content-value checks (see below)                           |
+
+### Rate bands
+
+The connector measures the publication rate over a sliding window and
+maps the observed Hz value through `publication_rate_hz` the same way content
+rules work: bands are checked best→worst, first match wins, and if
+nothing matches the level falls back to `publication_rate_default_level`. Omitting
+`publication_rate_hz` disables the rate check entirely.
+
+```json
+"publication_rate_hz": [
+  {"level": "NOMINAL",  "min": 8.0, "max": 12.0},
+  {"level": "DEGRADED", "min": 4.0, "max": 20.0}
+],
+"publication_rate_default_level": "CRITICAL"
+```
+
+For the example above, a 10 Hz target with ±20% acceptable:
+
+| Observed rate | Level     |
+|---------------|-----------|
+| `10.0`        | NOMINAL   |
+| `6.0`         | DEGRADED  |
+| `1.0`         | CRITICAL (falls through to `publication_rate_default_level`) |
+
+### Liveliness and the UNKNOWN vs INACTIVE distinction
+
+Keelson publishers declare a Zenoh liveliness token as long as they are
+running. The connector subscribes to liveliness changes on each
+expectation's `key_expr` (with `history=True`, so already-present tokens
+are picked up at startup). This drives the distinction between two
+failure modes:
+
+| Liveliness | Data                                       | Level     |
+|------------|--------------------------------------------|-----------|
+| absent     | —                                          | UNKNOWN   |
+| present    | no samples yet, or silent > `critical_after_s` | INACTIVE  |
+| present    | rate / content OK                          | NOMINAL   |
+
+Set `"require_liveliness": false` on an expectation when the data
+source doesn't declare a token (e.g. MCAP replays, AIS feeds bridged
+from outside the Keelson bus). The connector then falls back to
+sample-based activity detection only.
+
+### Content rules
+
+Content rules check a field on the decoded payload. Each rule has a
+list of `bands` that map value ranges (or equality matches) to health
+levels. Bands are checked best→worst; the first matching band wins.
+If no band matches, `default_level` is used (default: `CRITICAL`).
+
+```json
+{
+  "field": "value",
+  "bands": [
+    {"level": "NOMINAL",  "min": 12.0, "max": 14.5},
+    {"level": "DEGRADED", "min": 11.0, "max": 15.0},
+    {"level": "CRITICAL", "min": 10.0, "max": 16.0}
+  ],
+  "default_level": "CRITICAL"
+}
+```
+
+For the example above:
+
+| Voltage reading | Level     |
+|-----------------|-----------|
+| `13.2`          | NOMINAL   |
+| `11.5`          | DEGRADED  |
+| `15.5`          | CRITICAL  |
+| `9.0`           | CRITICAL (falls through to `default_level`) |
+
+Bands typically nest (NOMINAL ⊂ DEGRADED ⊂ CRITICAL) but this isn't
+enforced — they are simply checked in best→worst order. `min` and `max`
+are both optional; omit either to make the band one-sided.
+
+**Equality / set match** — bands can also match on equality instead of
+a numeric range. Use `equals` with a scalar (string, number, bool) or a
+list of scalars. `equals` takes precedence over `min`/`max`.
+
+```json
+{
+  "field": "quality",
+  "bands": [
+    {"level": "NOMINAL",  "equals": ["RTK_FIXED", "RTK_FLOAT"]},
+    {"level": "DEGRADED", "equals": "DGPS"},
+    {"level": "CRITICAL", "equals": "INVALID"}
+  ],
+  "default_level": "DEGRADED"
+}
+```
+
+This is handy for enum-like fields (GNSS fix quality, navigation
+status) and for boolean flags (`{"equals": false, "level": "CRITICAL"}`
+on an `is_healthy` field).
+
+Valid `level` names: `NOMINAL`, `DEGRADED`, `CRITICAL`, `INACTIVE`
+(prefix `HEALTH_` is also accepted).
+
+### Combining rate and content checks
+
+For each subsystem, the evaluator takes the **worst** level produced by
+the rate check and every content rule. The `SubsystemHealth.detail`
+string lists every non-nominal contributor. The overall
+`EntityHealth.level` is then the worst across all subsystems.
+
+### Health levels
+
+| Level         | When                                                              |
+|---------------|-------------------------------------------------------------------|
+| `NOMINAL`     | Liveliness present, rate in NOMINAL band, all content rules pass  |
+| `DEGRADED`    | A rate or content band resolved to DEGRADED                       |
+| `CRITICAL`    | A rate or content band resolved to CRITICAL                       |
+| `INACTIVE`    | Alive but silent longer than `inactive_after_s`                   |
+| `UNKNOWN`     | `require_liveliness` is true and no Zenoh liveliness token present |
+
+The overall `EntityHealth.level` is the worst level among all subsystems.
+
+## Keeping data local: monitoring sensors that don't leave the entity
+
+A common case: a sensor (e.g. a lidar on a drone) publishes
+high-bandwidth data inside the entity, but you only want the outside
+world to see an aggregated health summary — not the raw stream.
+
+This works naturally because the entity_health connector subscribes at
+the **local** Zenoh peer, so the sensor's traffic only needs to be
+visible inside the entity's mesh, not outside it.
+
+### Architecture
+
+```
+┌────────────────── drone ──────────────────┐
+│                                            │
+│  lidar driver ─► drone/internal/.../laser_scan/lidar_front
+│                          │                 │
+│                          ▼                 │
+│              entity_health connector       │
+│                          │                 │
+│                          ▼                 │
+│       drone/external/.../entity_health/health
+│                          │                 │
+└──────────────────────────┼─────────────────┘
+                           │
+                egress router / bridge
+                (allows only drone/external/**)
+                           │
+                           ▼
+                    fleet operator
+```
+
+Use two namespaces (or two Keelson realms):
+
+- `drone/internal/...` — everything produced locally; **never bridged**.
+- `drone/external/...` — only what the outside world should see (the
+  EntityHealth summary, possibly a low-rate position, etc.).
+
+The "stays inside" enforcement is a **Zenoh routing concern**, not an
+entity_health concern. Two common patterns:
+
+1. **Two routers**: an internal router on the drone with no WAN
+   `connect`, plus a bridge router that connects to both meshes with
+   `access_control` ACLs allowing only `drone/external/**` across.
+2. **One router with ACLs**: a single drone router whose
+   `access_control` JSON5 config denies any non-`drone/external/**` key
+   from being forwarded over its WAN endpoint.
+
+### Connector config
+
+The entity_health connector runs **inside the drone** and watches the
+internal namespace. Run it with `--realm drone/external` so its own
+output lands on the external namespace and gets bridged out:
+
+```json
+{
+  "name": "lidar_front",
+  "key_expr": "drone/internal/@v0/drone1/pubsub/laser_scan/lidar_front",
+  "inactive_after_s": 1.0,
+  "publication_rate_hz": [
+    {"level": "NOMINAL",  "min": 9.0, "max": 11.0},
+    {"level": "DEGRADED", "min": 5.0, "max": 15.0}
+  ],
+  "publication_rate_default_level": "CRITICAL",
+  "require_liveliness": true
+}
+```
+
+The operator only ever sees the aggregated `EntityHealth` message —
+the raw `laser_scan` payloads stay inside the drone.
+
+> **Note on lidar content checks**: today's content rules read a single
+> scalar field via `getattr`. They don't aggregate over `repeated`
+> fields like `LaserScan.ranges`. For pure rate + liveliness monitoring
+> the example above works as-is. To check scan content (e.g. "≥100
+> valid returns per scan") you'd publish a derived scalar from the
+> driver, or extend the evaluator with a small aggregation primitive.
+
+## Runtime reconfiguration
+
+Send a Zenoh GET on the `Configurable` `set_config` RPC key with a JSON
+body matching the schema above. Subscribers whose `key_expr` changed
+will be re-declared; unchanged ones are kept.
+
+## Tests
+
+```bash
+uv run pytest -vv connectors/entity_health/tests/                # all
+uv run pytest -vv -m "not e2e" connectors/entity_health/tests/   # unit only
+uv run pytest -vv -m e2e      connectors/entity_health/tests/    # e2e only
+```

--- a/connectors/entity_health/README.md
+++ b/connectors/entity_health/README.md
@@ -33,7 +33,7 @@ Each entry in `expectations` defines one monitored subsystem:
 
 | Field                | Description                                                        |
 |----------------------|--------------------------------------------------------------------|
-| `name`               | Subsystem name emitted in `SubsystemHealth.name`                   |
+| `name`               | Subsystem name emitted in `SourceHealth.name`                      |
 | `key_expr`           | Zenoh key expression to subscribe to (supports `*` / `**`)         |
 | `inactive_after_s`   | Silence longer than this → INACTIVE (default 10s)                  |
 | `window_s`           | Sliding window over which the publication rate is measured (default 10s) |
@@ -143,7 +143,7 @@ Valid `level` names: `NOMINAL`, `DEGRADED`, `CRITICAL`, `INACTIVE`
 ### Combining rate and content checks
 
 For each subsystem, the evaluator takes the **worst** level produced by
-the rate check and every content rule. The `SubsystemHealth.detail`
+the rate check and every content rule. The `SourceHealth.detail`
 string lists every non-nominal contributor. The overall
 `EntityHealth.level` is then the worst across all subsystems.
 

--- a/connectors/entity_health/README.md
+++ b/connectors/entity_health/README.md
@@ -1,11 +1,17 @@
 # entity_health connector
 
-Subscribes to a configurable set of Zenoh key-expressions, measures the
-publication rate and validates payload content against declarative
-expectations, and publishes a `keelson.EntityHealth` message on the
-`entity_health` subject.
+Watches a declarative set of `(source, subject)` pairs on the bus,
+measures the publication rate and validates payload content, and
+publishes a `keelson.EntityHealth` message on the `entity_health`
+subject.
 
-The active set of expectations can be replaced at runtime via the
+The proto layout is `EntityHealth → SourceHealth → SubjectHealth`: an
+**entity** is the system being monitored (a vessel, a drone), a
+**source** is one device on it (a GNSS receiver, a battery monitor), and
+each source publishes one or more **subjects** (e.g. `location_fix`,
+`battery_voltage_v`).
+
+The active configuration can be replaced at runtime via the
 `Configurable` RPC interface (`get_config` / `set_config`).
 
 ## Usage
@@ -25,16 +31,41 @@ See [`example-config.json`](example-config.json) for a full example.
 ```json
 {
   "publish_rate_hz": 1.0,
-  "expectations": [ ... ]
+  "realm": "test-realm",
+  "entity_id": "test-vessel",
+  "sources": [
+    {
+      "name": "gnss_main",
+      "subjects": [ ... ]
+    }
+  ]
 }
 ```
 
-Each entry in `expectations` defines one monitored subsystem:
+Top-level fields:
+
+| Field             | Description                                                       |
+|-------------------|-------------------------------------------------------------------|
+| `publish_rate_hz` | Rate at which the connector emits `EntityHealth` (default 0.1 Hz) |
+| `realm`           | Optional. Realm to use when monitoring sources. Defaults to `--realm`     |
+| `entity_id`       | Optional. Entity to monitor. Defaults to `--entity-id`. Override to watch a different entity than the one this connector publishes its own output on |
+| `sources`         | Required. One entry per device to monitor                         |
+
+Each `sources` entry has:
+
+| Field      | Description                                            |
+|------------|--------------------------------------------------------|
+| `name`     | The publisher's `source_id` — emitted in `SourceHealth.name` |
+| `subjects` | One entry per subject the source publishes             |
+
+Each `subjects` entry defines what to expect from one (source, subject)
+pair. The connector subscribes to the exact key
+`{realm}/@v0/{entity_id}/pubsub/{subject}/{source}` — wildcards are
+**not supported**: each entry maps to exactly one publisher.
 
 | Field                | Description                                                        |
 |----------------------|--------------------------------------------------------------------|
-| `name`               | Subject name emitted in `SubjectHealth.name`                       |
-| `key_expr`           | Zenoh key expression to subscribe to (supports `*` / `**`)         |
+| `name`               | Subject name (must exist in `subjects.yaml`); emitted in `SubjectHealth.name` |
 | `inactive_after_s`   | Silence longer than this → INACTIVE (default 10s)                  |
 | `window_s`           | Sliding window over which the publication rate is measured (default 10s) |
 | `publication_rate_hz`         | Tiered bands applied to the observed publication rate (see below)  |
@@ -146,8 +177,11 @@ For each subject, the evaluator emits one `CheckResult` per check that
 ran (the standard `activity` and `publication_rate` checks plus one per
 configured content rule), and `SubjectHealth.level` is the **worst**
 level across them. The per-check explanation lives on
-`SubjectHealth.checks[i].detail`. The overall `EntityHealth.level` is
-the worst across all subjects.
+`SubjectHealth.checks[i].detail`.
+
+Per-source rollup: `SourceHealth.level` is the worst level among the
+source's subjects. The overall `EntityHealth.level` is the worst level
+among all sources.
 
 ### Health levels
 
@@ -159,11 +193,11 @@ the worst across all subjects.
 | `INACTIVE`    | Alive but silent longer than `inactive_after_s`                   |
 | `UNKNOWN`     | `require_liveliness` is true and no Zenoh liveliness token present |
 
-The overall `EntityHealth.level` is the worst level among all subsystems.
+The overall `EntityHealth.level` is the worst level among all sources.
 
 ## Keeping data local: monitoring sensors that don't leave the entity
 
-A common case: a sensor (e.g. a lidar on a drone) publishes
+A common case: a sensor (e.g. a lidar on the entity) publishes
 high-bandwidth data inside the entity, but you only want the outside
 world to see an aggregated health summary — not the raw stream.
 
@@ -174,20 +208,20 @@ visible inside the entity's mesh, not outside it.
 ### Architecture
 
 ```
-┌────────────────── drone ──────────────────┐
+┌────────────────── entity ─────────────────┐
 │                                            │
-│  lidar driver ─► drone/internal/.../laser_scan/lidar_front
+│  lidar driver ─► entity/internal/.../laser_scan/lidar_front
 │                          │                 │
 │                          ▼                 │
 │              entity_health connector       │
 │                          │                 │
 │                          ▼                 │
-│       drone/external/.../entity_health/health
+│       entity/external/.../entity_health/health
 │                          │                 │
 └──────────────────────────┼─────────────────┘
                            │
                 egress router / bridge
-                (allows only drone/external/**)
+                (allows only entity/external/**)
                            │
                            ▼
                     fleet operator
@@ -195,42 +229,55 @@ visible inside the entity's mesh, not outside it.
 
 Use two namespaces (or two Keelson realms):
 
-- `drone/internal/...` — everything produced locally; **never bridged**.
-- `drone/external/...` — only what the outside world should see (the
+- `entity/internal/...` — everything produced locally; **never bridged**.
+- `entity/external/...` — only what the outside world should see (the
   EntityHealth summary, possibly a low-rate position, etc.).
 
 The "stays inside" enforcement is a **Zenoh routing concern**, not an
 entity_health concern. Two common patterns:
 
-1. **Two routers**: an internal router on the drone with no WAN
+1. **Two routers**: an internal router on the entity with no WAN
    `connect`, plus a bridge router that connects to both meshes with
-   `access_control` ACLs allowing only `drone/external/**` across.
-2. **One router with ACLs**: a single drone router whose
-   `access_control` JSON5 config denies any non-`drone/external/**` key
+   `access_control` ACLs allowing only `entity/external/**` across.
+2. **One router with ACLs**: a single router on the entity whose
+   `access_control` JSON5 config denies any non-`entity/external/**` key
    from being forwarded over its WAN endpoint.
 
 ### Connector config
 
-The entity_health connector runs **inside the drone** and watches the
-internal namespace. Run it with `--realm drone/external` so its own
-output lands on the external namespace and gets bridged out:
+The entity_health connector runs **inside the entity** and watches the
+internal namespace. Run it with `--realm entity/external` so its own
+output lands on the external namespace and gets bridged out, and use
+the config-level `realm`/`entity_id` to point the *monitored* keys at
+the internal namespace:
 
 ```json
 {
-  "name": "lidar_front",
-  "key_expr": "drone/internal/@v0/drone1/pubsub/laser_scan/lidar_front",
-  "inactive_after_s": 1.0,
-  "publication_rate_hz": [
-    {"level": "NOMINAL",  "min": 9.0, "max": 11.0},
-    {"level": "DEGRADED", "min": 5.0, "max": 15.0}
-  ],
-  "publication_rate_default_level": "CRITICAL",
-  "require_liveliness": true
+  "publish_rate_hz": 1.0,
+  "realm": "entity/internal",
+  "entity_id": "entity1",
+  "sources": [
+    {
+      "name": "lidar_front",
+      "subjects": [
+        {
+          "name": "laser_scan",
+          "inactive_after_s": 1.0,
+          "publication_rate_hz": [
+            {"level": "NOMINAL",  "min": 9.0, "max": 11.0},
+            {"level": "DEGRADED", "min": 5.0, "max": 15.0}
+          ],
+          "publication_rate_default_level": "CRITICAL",
+          "require_liveliness": true
+        }
+      ]
+    }
+  ]
 }
 ```
 
 The operator only ever sees the aggregated `EntityHealth` message —
-the raw `laser_scan` payloads stay inside the drone.
+the raw `laser_scan` payloads stay inside the entity.
 
 > **Note on lidar content checks**: today's content rules read a single
 > scalar field via `getattr`. They don't aggregate over `repeated`
@@ -242,8 +289,10 @@ the raw `laser_scan` payloads stay inside the drone.
 ## Runtime reconfiguration
 
 Send a Zenoh GET on the `Configurable` `set_config` RPC key with a JSON
-body matching the schema above. Subscribers whose `key_expr` changed
-will be re-declared; unchanged ones are kept.
+body matching the schema above. Subscribers whose derived key expression
+changed (because the source, subject, realm, or entity_id changed) are
+re-declared; unchanged (source, subject) pairs are kept and their
+sample history is preserved across the reconfiguration.
 
 ## Tests
 

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -26,7 +26,7 @@ import keelson
 from keelson import construct_pubsub_key, enclose, get_subject_from_pubsub_key
 from keelson.payloads.EntityHealth_pb2 import (
     EntityHealth,
-    SubsystemHealth,
+    SourceHealth,
 )
 from keelson.scaffolding import (
     setup_logging,
@@ -318,18 +318,18 @@ def set_config(new_config: dict) -> None:
 
 
 def _build_entity_health(
-    overall: int, subsystems: list, timestamp_ns: int
+    overall: int, sources: list, timestamp_ns: int
 ) -> EntityHealth:
     msg = EntityHealth()
     msg.timestamp.FromNanoseconds(timestamp_ns)
     msg.level = overall
     msg.rate_hz = float(CONFIG.get("publish_rate_hz", 0.1))
-    for s in subsystems:
-        sh = SubsystemHealth()
+    for s in sources:
+        sh = SourceHealth()
         sh.name = s.name
         sh.level = s.level
         sh.detail = s.detail
-        msg.subsystems.append(sh)
+        msg.sources.append(sh)
     return msg
 
 

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -27,7 +27,7 @@ from keelson import construct_pubsub_key, enclose, get_subject_from_pubsub_key
 from keelson.payloads.EntityHealth_pb2 import (
     CheckResult,
     EntityHealth,
-    SourceHealth,
+    SubjectHealth,
 )
 from keelson.scaffolding import (
     setup_logging,
@@ -319,20 +319,20 @@ def set_config(new_config: dict) -> None:
 
 
 def _build_entity_health(
-    overall: int, sources: list, timestamp_ns: int
+    overall: int, subjects: list, timestamp_ns: int
 ) -> EntityHealth:
     msg = EntityHealth()
     msg.timestamp.FromNanoseconds(timestamp_ns)
     msg.level = overall
     msg.rate_hz = float(CONFIG.get("publish_rate_hz", 0.1))
-    for s in sources:
-        sh = SourceHealth()
+    for s in subjects:
+        sh = SubjectHealth()
         sh.name = s.name
         sh.level = s.level
         sh.measured_publication_rate_hz = s.measured_publication_rate_hz
         for c in s.checks:
             sh.checks.append(CheckResult(name=c.name, level=c.level, detail=c.detail))
-        msg.sources.append(sh)
+        msg.subjects.append(sh)
     return msg
 
 

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -329,6 +329,7 @@ def _build_entity_health(
         sh.name = s.name
         sh.level = s.level
         sh.detail = s.detail
+        sh.measured_publication_rate_hz = s.measured_publication_rate_hz
         msg.sources.append(sh)
     return msg
 

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -27,6 +27,7 @@ from keelson import construct_pubsub_key, enclose, get_subject_from_pubsub_key
 from keelson.payloads.EntityHealth_pb2 import (
     CheckResult,
     EntityHealth,
+    SourceHealth,
     SubjectHealth,
 )
 from keelson.scaffolding import (
@@ -46,29 +47,42 @@ from entity_health.evaluator import (  # noqa: E402
     ContentRule,
     Evaluator,
     Expectation,
-    evaluate_all,
+    evaluate_grouped,
     parse_level,
 )
 
 logger = logging.getLogger("entity_health")
 
-JSON_SCHEMA = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+_SUBJECT_SCHEMA = {
     "type": "object",
-    "title": "Entity Health Config",
+    "required": ["name"],
     "properties": {
-        "publish_rate_hz": {"type": "number", "exclusiveMinimum": 0},
-        "expectations": {
+        "name": {"type": "string"},
+        "inactive_after_s": {"type": "number", "exclusiveMinimum": 0},
+        "window_s": {"type": "number", "exclusiveMinimum": 0},
+        "publication_rate_hz": {
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["name", "key_expr"],
+                "required": ["level"],
                 "properties": {
-                    "name": {"type": "string"},
-                    "key_expr": {"type": "string"},
-                    "inactive_after_s": {"type": "number", "exclusiveMinimum": 0},
-                    "window_s": {"type": "number", "exclusiveMinimum": 0},
-                    "publication_rate_hz": {
+                    "level": {"type": "string"},
+                    "min": {"type": "number"},
+                    "max": {"type": "number"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "publication_rate_default_level": {"type": "string"},
+        "require_liveliness": {"type": "boolean"},
+        "content_rules": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["field", "bands"],
+                "properties": {
+                    "field": {"type": "string"},
+                    "bands": {
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -77,68 +91,70 @@ JSON_SCHEMA = {
                                 "level": {"type": "string"},
                                 "min": {"type": "number"},
                                 "max": {"type": "number"},
-                            },
-                            "additionalProperties": False,
-                        },
-                    },
-                    "publication_rate_default_level": {"type": "string"},
-                    "require_liveliness": {"type": "boolean"},
-                    "content_rules": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["field", "bands"],
-                            "properties": {
-                                "field": {"type": "string"},
-                                "bands": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "required": ["level"],
-                                        "properties": {
-                                            "level": {"type": "string"},
-                                            "min": {"type": "number"},
-                                            "max": {"type": "number"},
-                                            "equals": {
+                                "equals": {
+                                    "anyOf": [
+                                        {"type": "string"},
+                                        {"type": "number"},
+                                        {"type": "boolean"},
+                                        {
+                                            "type": "array",
+                                            "items": {
                                                 "anyOf": [
                                                     {"type": "string"},
                                                     {"type": "number"},
                                                     {"type": "boolean"},
-                                                    {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "anyOf": [
-                                                                {"type": "string"},
-                                                                {"type": "number"},
-                                                                {"type": "boolean"},
-                                                            ]
-                                                        },
-                                                    },
                                                 ]
                                             },
                                         },
-                                        "additionalProperties": False,
-                                    },
+                                    ]
                                 },
-                                "default_level": {"type": "string"},
                             },
                             "additionalProperties": False,
                         },
+                    },
+                    "default_level": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+JSON_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Entity Health Config",
+    "properties": {
+        "publish_rate_hz": {"type": "number", "exclusiveMinimum": 0},
+        "realm": {"type": "string"},
+        "entity_id": {"type": "string"},
+        "sources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "subjects"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "subjects": {
+                        "type": "array",
+                        "items": _SUBJECT_SCHEMA,
                     },
                 },
                 "additionalProperties": False,
             },
         },
     },
-    "required": ["expectations"],
+    "required": ["sources"],
     "additionalProperties": False,
 }
 
-# Module-level state (cleared between tests)
+# Module-level state (cleared between tests). Subscribers, liveliness
+# subscribers, and evaluators are keyed by `(source_name, subject_name)`.
 PUBLISHERS: dict[str, zenoh.Publisher] = {}
-SUBSCRIBERS: dict[str, zenoh.Subscriber] = {}
-LIVELINESS_SUBSCRIBERS: dict[str, zenoh.Subscriber] = {}
-EVALUATORS: dict[str, Evaluator] = {}
+SUBSCRIBERS: dict[tuple[str, str], zenoh.Subscriber] = {}
+LIVELINESS_SUBSCRIBERS: dict[tuple[str, str], zenoh.Subscriber] = {}
+EVALUATORS: dict[tuple[str, str], Evaluator] = {}
 CONFIG: dict = {}
 STATE_LOCK = threading.Lock()
 SESSION: zenoh.Session | None = None
@@ -168,7 +184,6 @@ def _expectation_from_dict(d: dict) -> Expectation:
     ]
     kwargs: dict = {
         "name": d["name"],
-        "key_expr": d["key_expr"],
         "inactive_after_s": float(d.get("inactive_after_s", 10.0)),
         "window_s": float(d.get("window_s", 10.0)),
         "publication_rate_hz": publication_rate_hz,
@@ -182,6 +197,46 @@ def _expectation_from_dict(d: dict) -> Expectation:
             d["publication_rate_default_level"]
         )
     return Expectation(**kwargs)
+
+
+def _flatten_expectations(
+    config: dict,
+) -> "dict[tuple[str, str], Expectation]":
+    """Walk `sources[].subjects[]` into a (source, subject) → Expectation map.
+
+    Subject names must be unique within a source; collisions raise ValueError.
+    Source names must also be unique.
+    """
+    out: "dict[tuple[str, str], Expectation]" = {}
+    seen_sources: set[str] = set()
+    for src in config.get("sources", []):
+        source_name = src["name"]
+        if source_name in seen_sources:
+            raise ValueError(f"duplicate source name: {source_name!r}")
+        seen_sources.add(source_name)
+        seen_subjects: set[str] = set()
+        for subj in src.get("subjects", []):
+            subject_name = subj["name"]
+            if subject_name in seen_subjects:
+                raise ValueError(
+                    f"duplicate subject {subject_name!r} under source {source_name!r}"
+                )
+            seen_subjects.add(subject_name)
+            out[(source_name, subject_name)] = _expectation_from_dict(subj)
+    return out
+
+
+def _monitoring_realm_entity(
+    config: dict, args: argparse.Namespace | None
+) -> tuple[str, str]:
+    """Realm + entity to construct *monitored* key expressions.
+
+    Config takes precedence so an entity_health connector can watch a
+    different entity than the one it publishes its own output on.
+    """
+    realm = config.get("realm") or (args.realm if args is not None else "")
+    entity_id = config.get("entity_id") or (args.entity_id if args is not None else "")
+    return realm, entity_id
 
 
 def _decode_payload(key: str, raw: bytes):
@@ -204,45 +259,37 @@ def _decode_payload(key: str, raw: bytes):
         return None
 
 
-def _make_handler(name: str):
+def _make_handler(key: tuple[str, str]):
     def _handler(sample: zenoh.Sample):
         now = time.monotonic()
         payload = _decode_payload(str(sample.key_expr), sample.payload.to_bytes())
         with STATE_LOCK:
-            ev = EVALUATORS.get(name)
+            ev = EVALUATORS.get(key)
             if ev is not None:
                 ev.record(now, payload)
 
     return _handler
 
 
-def _make_liveliness_handler(name: str, own_source_id: str):
-    own_suffix = f"/{own_source_id}"
-
+def _make_liveliness_handler(key: tuple[str, str]):
     def _handler(sample: zenoh.Sample):
-        key = str(sample.key_expr)
-        # Liveliness subscribers match by intersection across all source_ids
-        # under the entity, so we receive our own token too. Ignore it —
-        # otherwise our own presence would mask the absence of the actual
-        # data publisher.
-        if key.endswith(own_suffix):
-            return
+        sample_key = str(sample.key_expr)
         with STATE_LOCK:
-            ev = EVALUATORS.get(name)
+            ev = EVALUATORS.get(key)
             if ev is None:
                 return
             if sample.kind == zenoh.SampleKind.PUT:
-                ev.set_alive(key)
-                logger.debug("LIVELINESS PUT %s ← %s", name, key)
+                ev.set_alive(sample_key)
+                logger.debug("LIVELINESS PUT %s ← %s", key, sample_key)
             elif sample.kind == zenoh.SampleKind.DELETE:
-                ev.set_dead(key)
-                logger.debug("LIVELINESS DELETE %s ← %s", name, key)
+                ev.set_dead(sample_key)
+                logger.debug("LIVELINESS DELETE %s ← %s", key, sample_key)
 
     return _handler
 
 
 def _apply_config(new_config: dict) -> None:
-    """Replace expectations (and their subscribers) with a new set."""
+    """Replace the (source, subject) expectation set and their subscribers."""
     validate(new_config, JSON_SCHEMA)
 
     if SESSION is None:
@@ -252,57 +299,66 @@ def _apply_config(new_config: dict) -> None:
         CONFIG.update(new_config)
         return
 
+    realm, entity_id = _monitoring_realm_entity(new_config, ARGS)
+
     with STATE_LOCK:
-        desired = {
-            e["name"]: _expectation_from_dict(e) for e in new_config["expectations"]
+        desired = _flatten_expectations(new_config)
+        # (source, subject) → key_expr — built once so teardown and setup
+        # can compare against each evaluator's current key without recomputing.
+        desired_keys = {
+            (source, subject): construct_pubsub_key(realm, entity_id, subject, source)
+            for (source, subject) in desired
         }
 
         # Remove subscribers that are gone or whose key_expr changed
-        for name in list(SUBSCRIBERS.keys()):
-            if (
-                name not in desired
-                or desired[name].key_expr != EVALUATORS[name].expectation.key_expr
-            ):
+        for key in list(SUBSCRIBERS.keys()):
+            current_key_expr = SUBSCRIBERS[key].key_expr  # set below at decl time
+            if key not in desired or desired_keys[key] != current_key_expr:
                 try:
-                    SUBSCRIBERS.pop(name).undeclare()
+                    SUBSCRIBERS.pop(key).undeclare()
                 except Exception:
                     logger.warning(
-                        "Failed to undeclare subscriber %s", name, exc_info=True
+                        "Failed to undeclare subscriber %s", key, exc_info=True
                     )
                 try:
-                    if name in LIVELINESS_SUBSCRIBERS:
-                        LIVELINESS_SUBSCRIBERS.pop(name).undeclare()
+                    if key in LIVELINESS_SUBSCRIBERS:
+                        LIVELINESS_SUBSCRIBERS.pop(key).undeclare()
                 except Exception:
                     logger.warning(
                         "Failed to undeclare liveliness subscriber %s",
-                        name,
+                        key,
                         exc_info=True,
                     )
-                EVALUATORS.pop(name, None)
+                EVALUATORS.pop(key, None)
 
         # Add new / replaced subscribers, or update bands on existing ones
-        for name, exp in desired.items():
-            if name in EVALUATORS:
-                # Same name + same key_expr (key_expr changes were handled above
-                # by tearing down). Update bands / thresholds in place so the
-                # next evaluate() picks them up. Sample history is preserved.
-                ev = EVALUATORS[name]
+        for key, exp in desired.items():
+            if key in EVALUATORS:
+                # Same (source, subject) and same key_expr (key changes were
+                # handled above by tearing down). Update bands / thresholds in
+                # place so the next evaluate() picks them up. Sample history
+                # is preserved.
+                ev = EVALUATORS[key]
                 ev.expectation = exp
                 ev.window_s = exp.window_s
             else:
-                EVALUATORS[name] = Evaluator(exp)
-                SUBSCRIBERS[name] = SESSION.declare_subscriber(
-                    exp.key_expr, _make_handler(name)
-                )
+                key_expr = desired_keys[key]
+                EVALUATORS[key] = Evaluator(exp)
+                sub = SESSION.declare_subscriber(key_expr, _make_handler(key))
+                # Stash the key_expr on the subscriber so reconfig can compare
+                # without rebuilding it from realm/entity/source/subject.
+                try:
+                    sub.key_expr = key_expr  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+                SUBSCRIBERS[key] = sub
                 # Liveliness subscriber with history=True seeds already-live tokens.
-                # Pass our own source_id so the handler can filter our own token.
-                own_source_id = ARGS.source_id if ARGS is not None else ""
-                LIVELINESS_SUBSCRIBERS[name] = SESSION.liveliness().declare_subscriber(
-                    exp.key_expr,
-                    _make_liveliness_handler(name, own_source_id),
+                LIVELINESS_SUBSCRIBERS[key] = SESSION.liveliness().declare_subscriber(
+                    key_expr,
+                    _make_liveliness_handler(key),
                     history=True,
                 )
-                logger.info("Subscribed %s → %s", name, exp.key_expr)
+                logger.info("Subscribed %s → %s", key, key_expr)
 
         CONFIG.clear()
         CONFIG.update(new_config)
@@ -319,20 +375,27 @@ def set_config(new_config: dict) -> None:
 
 
 def _build_entity_health(
-    overall: int, subjects: list, timestamp_ns: int
+    overall: int, sources: list, timestamp_ns: int
 ) -> EntityHealth:
     msg = EntityHealth()
     msg.timestamp.FromNanoseconds(timestamp_ns)
     msg.level = overall
     msg.rate_hz = float(CONFIG.get("publish_rate_hz", 0.1))
-    for s in subjects:
-        sh = SubjectHealth()
-        sh.name = s.name
-        sh.level = s.level
-        sh.measured_publication_rate_hz = s.measured_publication_rate_hz
-        for c in s.checks:
-            sh.checks.append(CheckResult(name=c.name, level=c.level, detail=c.detail))
-        msg.subjects.append(sh)
+    for src in sources:
+        sh = SourceHealth()
+        sh.name = src.name
+        sh.level = src.level
+        for s in src.subjects:
+            subj = SubjectHealth()
+            subj.name = s.name
+            subj.level = s.level
+            subj.measured_publication_rate_hz = s.measured_publication_rate_hz
+            for c in s.checks:
+                subj.checks.append(
+                    CheckResult(name=c.name, level=c.level, detail=c.detail)
+                )
+            sh.subjects.append(subj)
+        msg.sources.append(sh)
     return msg
 
 
@@ -365,8 +428,8 @@ def run(session: zenoh.Session, args: argparse.Namespace) -> None:
 
         now = time.monotonic()
         with STATE_LOCK:
-            overall, states = evaluate_all(EVALUATORS.values(), now)
-        msg = _build_entity_health(overall, states, time.time_ns())
+            overall, sources = evaluate_grouped(EVALUATORS, now)
+        msg = _build_entity_health(overall, sources, time.time_ns())
         PUBLISHERS["entity_health"].put(
             enclose(msg.SerializeToString(), enclosed_at=time.time_ns())
         )

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -25,6 +25,7 @@ from jsonschema import validate, ValidationError
 import keelson
 from keelson import construct_pubsub_key, enclose, get_subject_from_pubsub_key
 from keelson.payloads.EntityHealth_pb2 import (
+    CheckResult,
     EntityHealth,
     SourceHealth,
 )
@@ -328,8 +329,9 @@ def _build_entity_health(
         sh = SourceHealth()
         sh.name = s.name
         sh.level = s.level
-        sh.detail = s.detail
         sh.measured_publication_rate_hz = s.measured_publication_rate_hz
+        for c in s.checks:
+            sh.checks.append(CheckResult(name=c.name, level=c.level, detail=c.detail))
         msg.sources.append(sh)
     return msg
 

--- a/connectors/entity_health/bin/entity_health2keelson.py
+++ b/connectors/entity_health/bin/entity_health2keelson.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+
+"""Entity health connector.
+
+Subscribes to a set of Zenoh key expressions, measures publication rate
+and validates payload content against declarative expectations, and
+publishes a keelson.EntityHealth message on the `entity_health` subject.
+
+Reconfigurable at runtime via the Configurable RPC interface.
+"""
+
+# pylint: disable=duplicate-code
+
+import sys
+import json
+import time
+import logging
+import argparse
+import threading
+from pathlib import Path
+
+import zenoh
+from jsonschema import validate, ValidationError
+
+import keelson
+from keelson import construct_pubsub_key, enclose, get_subject_from_pubsub_key
+from keelson.payloads.EntityHealth_pb2 import (
+    EntityHealth,
+    SubsystemHealth,
+)
+from keelson.scaffolding import (
+    setup_logging,
+    add_common_arguments,
+    create_zenoh_config,
+    declare_liveliness_token,
+    make_configurable,
+)
+
+# Add package dir to path so we can import the entity_health package
+# alongside the bin script when running from source.
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG_ROOT))
+from entity_health.evaluator import (  # noqa: E402
+    Band,
+    ContentRule,
+    Evaluator,
+    Expectation,
+    evaluate_all,
+    parse_level,
+)
+
+logger = logging.getLogger("entity_health")
+
+JSON_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Entity Health Config",
+    "properties": {
+        "publish_rate_hz": {"type": "number", "exclusiveMinimum": 0},
+        "expectations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "key_expr"],
+                "properties": {
+                    "name": {"type": "string"},
+                    "key_expr": {"type": "string"},
+                    "inactive_after_s": {"type": "number", "exclusiveMinimum": 0},
+                    "window_s": {"type": "number", "exclusiveMinimum": 0},
+                    "publication_rate_hz": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["level"],
+                            "properties": {
+                                "level": {"type": "string"},
+                                "min": {"type": "number"},
+                                "max": {"type": "number"},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                    "publication_rate_default_level": {"type": "string"},
+                    "require_liveliness": {"type": "boolean"},
+                    "content_rules": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["field", "bands"],
+                            "properties": {
+                                "field": {"type": "string"},
+                                "bands": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["level"],
+                                        "properties": {
+                                            "level": {"type": "string"},
+                                            "min": {"type": "number"},
+                                            "max": {"type": "number"},
+                                            "equals": {
+                                                "anyOf": [
+                                                    {"type": "string"},
+                                                    {"type": "number"},
+                                                    {"type": "boolean"},
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {"type": "string"},
+                                                                {"type": "number"},
+                                                                {"type": "boolean"},
+                                                            ]
+                                                        },
+                                                    },
+                                                ]
+                                            },
+                                        },
+                                        "additionalProperties": False,
+                                    },
+                                },
+                                "default_level": {"type": "string"},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["expectations"],
+    "additionalProperties": False,
+}
+
+# Module-level state (cleared between tests)
+PUBLISHERS: dict[str, zenoh.Publisher] = {}
+SUBSCRIBERS: dict[str, zenoh.Subscriber] = {}
+LIVELINESS_SUBSCRIBERS: dict[str, zenoh.Subscriber] = {}
+EVALUATORS: dict[str, Evaluator] = {}
+CONFIG: dict = {}
+STATE_LOCK = threading.Lock()
+SESSION: zenoh.Session | None = None
+ARGS: argparse.Namespace | None = None
+
+
+def _content_rule_from_dict(r: dict) -> ContentRule:
+    bands = [
+        Band(
+            level=parse_level(b["level"]),
+            min=b.get("min"),
+            max=b.get("max"),
+            equals=b.get("equals"),
+        )
+        for b in r["bands"]
+    ]
+    kwargs: dict = {"field": r["field"], "bands": bands}
+    if "default_level" in r:
+        kwargs["default_level"] = parse_level(r["default_level"])
+    return ContentRule(**kwargs)
+
+
+def _expectation_from_dict(d: dict) -> Expectation:
+    publication_rate_hz = [
+        Band(level=parse_level(b["level"]), min=b.get("min"), max=b.get("max"))
+        for b in d.get("publication_rate_hz", [])
+    ]
+    kwargs: dict = {
+        "name": d["name"],
+        "key_expr": d["key_expr"],
+        "inactive_after_s": float(d.get("inactive_after_s", 10.0)),
+        "window_s": float(d.get("window_s", 10.0)),
+        "publication_rate_hz": publication_rate_hz,
+        "content_rules": [
+            _content_rule_from_dict(r) for r in d.get("content_rules", [])
+        ],
+        "require_liveliness": bool(d.get("require_liveliness", True)),
+    }
+    if "publication_rate_default_level" in d:
+        kwargs["publication_rate_default_level"] = parse_level(
+            d["publication_rate_default_level"]
+        )
+    return Expectation(**kwargs)
+
+
+def _decode_payload(key: str, raw: bytes):
+    """Decode an Envelope + typed payload. Returns None on failure."""
+    try:
+        _received_at, _enclosed_at, payload_bytes = keelson.uncover(raw)
+    except Exception:
+        logger.debug("Failed to uncover envelope on %s", key, exc_info=True)
+        return None
+    try:
+        subject = get_subject_from_pubsub_key(key)
+    except Exception:
+        return None
+    try:
+        return keelson.decode_protobuf_payload_from_type_name(
+            payload_bytes, keelson.get_subject_schema(subject)
+        )
+    except Exception:
+        logger.debug("Failed to decode payload for subject=%s", subject, exc_info=True)
+        return None
+
+
+def _make_handler(name: str):
+    def _handler(sample: zenoh.Sample):
+        now = time.monotonic()
+        payload = _decode_payload(str(sample.key_expr), sample.payload.to_bytes())
+        with STATE_LOCK:
+            ev = EVALUATORS.get(name)
+            if ev is not None:
+                ev.record(now, payload)
+
+    return _handler
+
+
+def _make_liveliness_handler(name: str, own_source_id: str):
+    own_suffix = f"/{own_source_id}"
+
+    def _handler(sample: zenoh.Sample):
+        key = str(sample.key_expr)
+        # Liveliness subscribers match by intersection across all source_ids
+        # under the entity, so we receive our own token too. Ignore it —
+        # otherwise our own presence would mask the absence of the actual
+        # data publisher.
+        if key.endswith(own_suffix):
+            return
+        with STATE_LOCK:
+            ev = EVALUATORS.get(name)
+            if ev is None:
+                return
+            if sample.kind == zenoh.SampleKind.PUT:
+                ev.set_alive(key)
+                logger.debug("LIVELINESS PUT %s ← %s", name, key)
+            elif sample.kind == zenoh.SampleKind.DELETE:
+                ev.set_dead(key)
+                logger.debug("LIVELINESS DELETE %s ← %s", name, key)
+
+    return _handler
+
+
+def _apply_config(new_config: dict) -> None:
+    """Replace expectations (and their subscribers) with a new set."""
+    validate(new_config, JSON_SCHEMA)
+
+    if SESSION is None:
+        # Called during initial bootstrap before the session is open:
+        # just stash the parsed config; subscribers are declared in run().
+        CONFIG.clear()
+        CONFIG.update(new_config)
+        return
+
+    with STATE_LOCK:
+        desired = {
+            e["name"]: _expectation_from_dict(e) for e in new_config["expectations"]
+        }
+
+        # Remove subscribers that are gone or whose key_expr changed
+        for name in list(SUBSCRIBERS.keys()):
+            if (
+                name not in desired
+                or desired[name].key_expr != EVALUATORS[name].expectation.key_expr
+            ):
+                try:
+                    SUBSCRIBERS.pop(name).undeclare()
+                except Exception:
+                    logger.warning(
+                        "Failed to undeclare subscriber %s", name, exc_info=True
+                    )
+                try:
+                    if name in LIVELINESS_SUBSCRIBERS:
+                        LIVELINESS_SUBSCRIBERS.pop(name).undeclare()
+                except Exception:
+                    logger.warning(
+                        "Failed to undeclare liveliness subscriber %s",
+                        name,
+                        exc_info=True,
+                    )
+                EVALUATORS.pop(name, None)
+
+        # Add new / replaced subscribers, or update bands on existing ones
+        for name, exp in desired.items():
+            if name in EVALUATORS:
+                # Same name + same key_expr (key_expr changes were handled above
+                # by tearing down). Update bands / thresholds in place so the
+                # next evaluate() picks them up. Sample history is preserved.
+                ev = EVALUATORS[name]
+                ev.expectation = exp
+                ev.window_s = exp.window_s
+            else:
+                EVALUATORS[name] = Evaluator(exp)
+                SUBSCRIBERS[name] = SESSION.declare_subscriber(
+                    exp.key_expr, _make_handler(name)
+                )
+                # Liveliness subscriber with history=True seeds already-live tokens.
+                # Pass our own source_id so the handler can filter our own token.
+                own_source_id = ARGS.source_id if ARGS is not None else ""
+                LIVELINESS_SUBSCRIBERS[name] = SESSION.liveliness().declare_subscriber(
+                    exp.key_expr,
+                    _make_liveliness_handler(name, own_source_id),
+                    history=True,
+                )
+                logger.info("Subscribed %s → %s", name, exp.key_expr)
+
+        CONFIG.clear()
+        CONFIG.update(new_config)
+
+
+def get_config() -> dict:
+    with STATE_LOCK:
+        return json.loads(json.dumps(CONFIG))  # deep copy
+
+
+def set_config(new_config: dict) -> None:
+    logger.info("Applying new config via RPC")
+    _apply_config(new_config)
+
+
+def _build_entity_health(
+    overall: int, subsystems: list, timestamp_ns: int
+) -> EntityHealth:
+    msg = EntityHealth()
+    msg.timestamp.FromNanoseconds(timestamp_ns)
+    msg.level = overall
+    msg.rate_hz = float(CONFIG.get("publish_rate_hz", 0.1))
+    for s in subsystems:
+        sh = SubsystemHealth()
+        sh.name = s.name
+        sh.level = s.level
+        sh.detail = s.detail
+        msg.subsystems.append(sh)
+    return msg
+
+
+def run(session: zenoh.Session, args: argparse.Namespace) -> None:
+    global SESSION
+    SESSION = session
+
+    # Declare subscribers for initial config
+    _apply_config(dict(CONFIG))
+
+    # Wire up Configurable RPC
+    make_configurable(
+        session,
+        args.realm,
+        args.entity_id,
+        args.source_id,
+        get_config,
+        set_config,
+    )
+
+    key_health = construct_pubsub_key(
+        args.realm, args.entity_id, "entity_health", args.source_id
+    )
+    PUBLISHERS["entity_health"] = session.declare_publisher(key_health)
+    logger.info("Publishing EntityHealth on %s", key_health)
+
+    while True:
+        rate = max(float(CONFIG.get("publish_rate_hz", 0.1)), 0.01)
+        time.sleep(1.0 / rate)
+
+        now = time.monotonic()
+        with STATE_LOCK:
+            overall, states = evaluate_all(EVALUATORS.values(), now)
+        msg = _build_entity_health(overall, states, time.time_ns())
+        PUBLISHERS["entity_health"].put(
+            enclose(msg.SerializeToString(), enclosed_at=time.time_ns())
+        )
+
+
+def main() -> None:
+    global ARGS
+    parser = argparse.ArgumentParser(
+        prog="entity_health2keelson",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=__doc__,
+    )
+    add_common_arguments(parser)
+    parser.add_argument("-r", "--realm", type=str, required=True)
+    parser.add_argument("-e", "--entity-id", type=str, required=True)
+    parser.add_argument("-s", "--source-id", type=str, required=True)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to the JSON configuration file.",
+    )
+    args = parser.parse_args()
+    ARGS = args
+
+    setup_logging(level=args.log_level)
+
+    try:
+        initial = json.loads(args.config.read_text(encoding="UTF-8"))
+        validate(initial, JSON_SCHEMA)
+    except json.JSONDecodeError:
+        logger.exception("Config file is not valid JSON")
+        sys.exit(1)
+    except ValidationError:
+        logger.exception("Config file does not validate against schema")
+        sys.exit(1)
+
+    CONFIG.clear()
+    CONFIG.update(initial)
+
+    zconf = create_zenoh_config(
+        mode=args.mode,
+        connect=args.connect,
+        listen=args.listen,
+    )
+
+    logger.info("Opening Zenoh session...")
+    with zenoh.open(zconf) as session:
+        with declare_liveliness_token(
+            session, args.realm, args.entity_id, args.source_id
+        ):
+            try:
+                run(session, args)
+            except KeyboardInterrupt:
+                logger.info("Shutting down on user request")
+                sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/connectors/entity_health/entity_health/__init__.py
+++ b/connectors/entity_health/entity_health/__init__.py
@@ -4,17 +4,19 @@ Public surface used by both the bin/ entry point and the tests.
 """
 
 from .evaluator import (
+    CheckResult,
     Expectation,
     ContentRule,
-    SubsystemState,
+    SourceState,
     Evaluator,
     evaluate_all,
 )
 
 __all__ = [
+    "CheckResult",
     "Expectation",
     "ContentRule",
-    "SubsystemState",
+    "SourceState",
     "Evaluator",
     "evaluate_all",
 ]

--- a/connectors/entity_health/entity_health/__init__.py
+++ b/connectors/entity_health/entity_health/__init__.py
@@ -7,7 +7,7 @@ from .evaluator import (
     CheckResult,
     Expectation,
     ContentRule,
-    SourceState,
+    SubjectState,
     Evaluator,
     evaluate_all,
 )
@@ -16,7 +16,7 @@ __all__ = [
     "CheckResult",
     "Expectation",
     "ContentRule",
-    "SourceState",
+    "SubjectState",
     "Evaluator",
     "evaluate_all",
 ]

--- a/connectors/entity_health/entity_health/__init__.py
+++ b/connectors/entity_health/entity_health/__init__.py
@@ -7,16 +7,18 @@ from .evaluator import (
     CheckResult,
     Expectation,
     ContentRule,
+    SourceState,
     SubjectState,
     Evaluator,
-    evaluate_all,
+    evaluate_grouped,
 )
 
 __all__ = [
     "CheckResult",
     "Expectation",
     "ContentRule",
+    "SourceState",
     "SubjectState",
     "Evaluator",
-    "evaluate_all",
+    "evaluate_grouped",
 ]

--- a/connectors/entity_health/entity_health/__init__.py
+++ b/connectors/entity_health/entity_health/__init__.py
@@ -1,0 +1,20 @@
+"""Entity health monitor connector package.
+
+Public surface used by both the bin/ entry point and the tests.
+"""
+
+from .evaluator import (
+    Expectation,
+    ContentRule,
+    SubsystemState,
+    Evaluator,
+    evaluate_all,
+)
+
+__all__ = [
+    "Expectation",
+    "ContentRule",
+    "SubsystemState",
+    "Evaluator",
+    "evaluate_all",
+]

--- a/connectors/entity_health/entity_health/evaluator.py
+++ b/connectors/entity_health/entity_health/evaluator.py
@@ -172,8 +172,8 @@ class CheckResult:
 
 
 @dataclass
-class SourceState:
-    """Current per-source status summary.
+class SubjectState:
+    """Current per-subject status summary.
 
     All structured per-check info lives in `checks`. Liveliness failures
     are conveyed by `level == HEALTH_UNKNOWN` with `checks == []`.
@@ -189,7 +189,7 @@ class Evaluator:
     """Per-expectation state: sample timestamps + latest payload.
 
     `record(now, payload)` is called from the subscriber callback.
-    `evaluate(now)` produces a `SourceState` for publishing.
+    `evaluate(now)` produces a `SubjectState` for publishing.
     """
 
     def __init__(self, expectation: Expectation, window_s: float | None = None):
@@ -268,14 +268,14 @@ class Evaluator:
             )
         return CheckResult("activity", HEALTH_NOMINAL)
 
-    def evaluate(self, now: float) -> SourceState:
+    def evaluate(self, now: float) -> SubjectState:
         exp = self.expectation
         rate = self.observed_rate_hz(now)
 
         # Liveliness gate: source-level UNKNOWN carries the meaning on its own;
         # no checks are emitted because nothing else can be evaluated.
         if exp.require_liveliness and not self.is_alive:
-            return SourceState(exp.name, HEALTH_UNKNOWN, rate, [])
+            return SubjectState(exp.name, HEALTH_UNKNOWN, rate, [])
 
         # Activity check: always runs, and gates rate + content rules. If we
         # haven't seen samples within `inactive_after_s`, only `activity` is
@@ -283,7 +283,7 @@ class Evaluator:
         # be misleading.
         activity = self._activity_check(now)
         if activity.level != HEALTH_NOMINAL:
-            return SourceState(exp.name, activity.level, rate, [activity])
+            return SubjectState(exp.name, activity.level, rate, [activity])
 
         # Full eval: activity + rate + content rules
         checks: list[CheckResult] = [
@@ -294,15 +294,15 @@ class Evaluator:
             checks.append(CheckResult(rule.field, *rule.evaluate(self._last_payload)))
 
         overall = worst(*(c.level for c in checks)) or HEALTH_NOMINAL
-        return SourceState(exp.name, overall, rate, checks)
+        return SubjectState(exp.name, overall, rate, checks)
 
 
 def evaluate_all(
     evaluators: Iterable[Evaluator], now: float
-) -> tuple[int, list[SourceState]]:
-    """Aggregate all subsystems into an overall health level.
+) -> tuple[int, list[SubjectState]]:
+    """Aggregate all subjects into an overall health level.
 
-    Overall level = worst (lowest-rank) of any non-UNKNOWN subsystem,
+    Overall level = worst (lowest-rank) of any non-UNKNOWN subject,
     or UNKNOWN if the list is empty / all unknown.
     """
     states = [ev.evaluate(now) for ev in evaluators]

--- a/connectors/entity_health/entity_health/evaluator.py
+++ b/connectors/entity_health/entity_health/evaluator.py
@@ -163,20 +163,33 @@ class Expectation:
 
 
 @dataclass
-class SubsystemState:
-    """Current per-subsystem status summary."""
+class CheckResult:
+    """Result of a single check (publication rate or one content rule)."""
 
     name: str
     level: int
-    detail: str
+    detail: str = ""
+
+
+@dataclass
+class SourceState:
+    """Current per-source status summary.
+
+    All structured per-check info lives in `checks`. Liveliness failures
+    are conveyed by `level == HEALTH_UNKNOWN` with `checks == []`.
+    """
+
+    name: str
+    level: int
     measured_publication_rate_hz: float = 0.0
+    checks: list[CheckResult] = field(default_factory=list)
 
 
 class Evaluator:
     """Per-expectation state: sample timestamps + latest payload.
 
     `record(now, payload)` is called from the subscriber callback.
-    `evaluate(now)` produces a `SubsystemState` for publishing.
+    `evaluate(now)` produces a `SourceState` for publishing.
     """
 
     def __init__(self, expectation: Expectation, window_s: float | None = None):
@@ -235,55 +248,58 @@ class Evaluator:
             f"rate {observed:.2f}Hz outside all rate bands",
         )
 
-    def evaluate(self, now: float) -> SubsystemState:
+    def _activity_check(self, now: float) -> CheckResult:
+        """Evaluate the standard `activity` check (samples flowing recently)."""
         exp = self.expectation
-        rate = self.observed_rate_hz(now)
-
-        # Liveliness gate: if required and no token is present → UNKNOWN.
-        if exp.require_liveliness and not self.is_alive:
-            return SubsystemState(
-                exp.name, HEALTH_UNKNOWN, "no liveliness token present", rate
-            )
-
-        # Alive (or liveliness not required) but no samples yet → INACTIVE.
         if self._last_sample_at is None:
             detail = (
                 "alive but no samples received yet"
                 if exp.require_liveliness
                 else "no samples received yet"
             )
-            return SubsystemState(exp.name, HEALTH_INACTIVE, detail, rate)
+            return CheckResult("activity", HEALTH_INACTIVE, detail)
 
         silence = now - self._last_sample_at
         if silence > exp.inactive_after_s:
-            return SubsystemState(
-                exp.name,
+            return CheckResult(
+                "activity",
                 HEALTH_INACTIVE,
                 f"silent for {silence:.1f}s (limit {exp.inactive_after_s}s)",
-                rate,
             )
+        return CheckResult("activity", HEALTH_NOMINAL)
 
-        # Collect (level, detail) from rate check + every content rule
-        results: list[tuple[int, str]] = [self._publication_rate_level(now)]
+    def evaluate(self, now: float) -> SourceState:
+        exp = self.expectation
+        rate = self.observed_rate_hz(now)
+
+        # Liveliness gate: source-level UNKNOWN carries the meaning on its own;
+        # no checks are emitted because nothing else can be evaluated.
+        if exp.require_liveliness and not self.is_alive:
+            return SourceState(exp.name, HEALTH_UNKNOWN, rate, [])
+
+        # Activity check: always runs, and gates rate + content rules. If we
+        # haven't seen samples within `inactive_after_s`, only `activity` is
+        # emitted — evaluating rate or content rules without samples would
+        # be misleading.
+        activity = self._activity_check(now)
+        if activity.level != HEALTH_NOMINAL:
+            return SourceState(exp.name, activity.level, rate, [activity])
+
+        # Full eval: activity + rate + content rules
+        checks: list[CheckResult] = [
+            activity,
+            CheckResult("publication_rate", *self._publication_rate_level(now)),
+        ]
         for rule in exp.content_rules:
-            results.append(rule.evaluate(self._last_payload))
+            checks.append(CheckResult(rule.field, *rule.evaluate(self._last_payload)))
 
-        overall = worst(*(lv for lv, _ in results))
-        if overall == HEALTH_NOMINAL or overall == HEALTH_UNKNOWN:
-            return SubsystemState(
-                exp.name, overall or HEALTH_NOMINAL, "ok", rate
-            )
-
-        # Build a detail string from all non-nominal contributors
-        details = [d for lv, d in results if lv != HEALTH_NOMINAL and d]
-        return SubsystemState(
-            exp.name, overall, "; ".join(details) or "degraded", rate
-        )
+        overall = worst(*(c.level for c in checks)) or HEALTH_NOMINAL
+        return SourceState(exp.name, overall, rate, checks)
 
 
 def evaluate_all(
     evaluators: Iterable[Evaluator], now: float
-) -> tuple[int, list[SubsystemState]]:
+) -> tuple[int, list[SourceState]]:
     """Aggregate all subsystems into an overall health level.
 
     Overall level = worst (lowest-rank) of any non-UNKNOWN subsystem,

--- a/connectors/entity_health/entity_health/evaluator.py
+++ b/connectors/entity_health/entity_health/evaluator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, Deque, Iterable
+from typing import Any, Deque, Mapping
 
 # HealthLevel enum values mirror keelson.EntityHealth_pb2.HealthLevel.
 # Duplicated here to keep the evaluator importable without the generated
@@ -145,10 +145,14 @@ class ContentRule:
 
 @dataclass
 class Expectation:
-    """Declarative definition of what a subsystem should look like on the bus."""
+    """Declarative definition of one (source, subject) pair on the bus.
+
+    `name` is the subject name (matches `SubjectHealth.name`). The owning
+    source is tracked outside this dataclass — Expectations are looked up
+    by `(source_name, subject_name)` keys.
+    """
 
     name: str
-    key_expr: str
     inactive_after_s: float = 10.0
     window_s: float = 10.0
     publication_rate_hz: list[Band] = field(default_factory=list)
@@ -175,14 +179,24 @@ class CheckResult:
 class SubjectState:
     """Current per-subject status summary.
 
-    All structured per-check info lives in `checks`. Liveliness failures
-    are conveyed by `level == HEALTH_UNKNOWN` with `checks == []`.
+    `name` is the subject name. All structured per-check info lives in
+    `checks`. Liveliness failures are conveyed by `level == HEALTH_UNKNOWN`
+    with `checks == []`.
     """
 
     name: str
     level: int
     measured_publication_rate_hz: float = 0.0
     checks: list[CheckResult] = field(default_factory=list)
+
+
+@dataclass
+class SourceState:
+    """Aggregated health of one source (device) and its subjects."""
+
+    name: str
+    level: int
+    subjects: list[SubjectState] = field(default_factory=list)
 
 
 class Evaluator:
@@ -297,14 +311,30 @@ class Evaluator:
         return SubjectState(exp.name, overall, rate, checks)
 
 
-def evaluate_all(
-    evaluators: Iterable[Evaluator], now: float
-) -> tuple[int, list[SubjectState]]:
-    """Aggregate all subjects into an overall health level.
+def evaluate_grouped(
+    evaluators: Mapping[tuple[str, str], Evaluator], now: float
+) -> tuple[int, list[SourceState]]:
+    """Group evaluators by source and aggregate.
 
-    Overall level = worst (lowest-rank) of any non-UNKNOWN subject,
-    or UNKNOWN if the list is empty / all unknown.
+    Keys are `(source_name, subject_name)`. Returns the entity-wide
+    overall level (worst of any non-UNKNOWN source, UNKNOWN otherwise)
+    and one `SourceState` per source — each rolling its subjects up via
+    `worst()`. Source order is the insertion order of `evaluators`.
     """
-    states = [ev.evaluate(now) for ev in evaluators]
-    overall = worst(*(s.level for s in states))
-    return overall, states
+    by_source: dict[str, list[SubjectState]] = {}
+    for key, ev in evaluators.items():
+        source_name = key[0]
+        by_source.setdefault(source_name, []).append(ev.evaluate(now))
+
+    sources: list[SourceState] = []
+    for source_name, subjects in by_source.items():
+        sources.append(
+            SourceState(
+                name=source_name,
+                level=worst(*(s.level for s in subjects)),
+                subjects=subjects,
+            )
+        )
+
+    overall = worst(*(s.level for s in sources))
+    return overall, sources

--- a/connectors/entity_health/entity_health/evaluator.py
+++ b/connectors/entity_health/entity_health/evaluator.py
@@ -1,0 +1,287 @@
+"""Rate + content-rule evaluation for the entity_health connector.
+
+Pure logic with no Zenoh dependency so it can be unit-tested in isolation.
+Time is injected (monotonic seconds) — callers pass `now` explicitly.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Iterable
+
+# HealthLevel enum values mirror keelson.EntityHealth_pb2.HealthLevel.
+# Duplicated here to keep the evaluator importable without the generated
+# protobuf module (useful for fast unit tests).
+HEALTH_UNKNOWN = 0
+HEALTH_INACTIVE = 1
+HEALTH_CRITICAL = 2
+HEALTH_DEGRADED = 3
+HEALTH_NOMINAL = 4
+
+# Worst → best ranking. Lower rank wins when combining levels.
+_RANK = {
+    HEALTH_INACTIVE: 0,
+    HEALTH_CRITICAL: 1,
+    HEALTH_DEGRADED: 2,
+    HEALTH_NOMINAL: 3,
+    HEALTH_UNKNOWN: 4,
+}
+
+_LEVEL_BY_NAME = {
+    "UNKNOWN": HEALTH_UNKNOWN,
+    "INACTIVE": HEALTH_INACTIVE,
+    "CRITICAL": HEALTH_CRITICAL,
+    "DEGRADED": HEALTH_DEGRADED,
+    "NOMINAL": HEALTH_NOMINAL,
+}
+
+_NAME_BY_LEVEL = {v: k for k, v in _LEVEL_BY_NAME.items()}
+
+
+def parse_level(level: int | str) -> int:
+    """Accept either an int (HEALTH_*) or a string ("NOMINAL", "HEALTH_NOMINAL")."""
+    if isinstance(level, int):
+        if level not in _NAME_BY_LEVEL:
+            raise ValueError(f"unknown health level int: {level}")
+        return level
+    name = level.upper().removeprefix("HEALTH_")
+    if name not in _LEVEL_BY_NAME:
+        raise ValueError(f"unknown health level: {level}")
+    return _LEVEL_BY_NAME[name]
+
+
+def worst(*levels: int) -> int:
+    """Return the worst (lowest-rank) of the given levels, ignoring UNKNOWN."""
+    non_unknown = [lv for lv in levels if lv != HEALTH_UNKNOWN]
+    if not non_unknown:
+        return HEALTH_UNKNOWN
+    return min(non_unknown, key=lambda lv: _RANK.get(lv, 99))
+
+
+@dataclass
+class Band:
+    """A value predicate that maps to a specific health level.
+
+    Supports either a numeric range (`min`/`max`) or an equality / set
+    match (`equals` — scalar or list of scalars). If `equals` is set it
+    takes precedence over `min`/`max`.
+    """
+
+    level: int
+    min: float | None = None
+    max: float | None = None
+    equals: Any = None
+
+    def contains(self, value: Any) -> bool:
+        if self.equals is not None:
+            if isinstance(self.equals, (list, tuple, set)):
+                return value in self.equals
+            return value == self.equals
+        try:
+            if self.min is not None and value < self.min:
+                return False
+            if self.max is not None and value > self.max:
+                return False
+        except TypeError:
+            # Non-numeric value with a numeric band → no match
+            return False
+        return True
+
+
+@dataclass
+class ContentRule:
+    """Tiered range/equality check on a top-level proto field.
+
+    Bands are evaluated best→worst (NOMINAL first). The first band whose
+    predicate matches the field value wins. If no band matches, the
+    rule produces `default_level` (CRITICAL by default).
+    """
+
+    field: str
+    bands: list[Band] = field(default_factory=list)
+    default_level: int = HEALTH_CRITICAL
+
+    def __post_init__(self) -> None:
+        # Sort bands best→worst so we always return the most favourable match
+        self.bands.sort(key=lambda b: _RANK.get(b.level, 99), reverse=True)
+
+    def evaluate(self, payload: Any) -> tuple[int, str]:
+        """Return (level, detail). UNKNOWN means rule could not be applied."""
+        if payload is None:
+            return HEALTH_UNKNOWN, ""
+        try:
+            value = getattr(payload, self.field)
+        except AttributeError:
+            return HEALTH_DEGRADED, f"missing field {self.field}"
+
+        # If the field is a protobuf enum, also compute the symbolic name so
+        # that bands can match on either the int or the enum name string.
+        name: str | None = None
+        try:
+            desc = type(payload).DESCRIPTOR.fields_by_name.get(self.field)
+            if desc is not None and desc.enum_type is not None:
+                enum_value = desc.enum_type.values_by_number.get(value)
+                if enum_value is not None:
+                    name = enum_value.name
+        except (AttributeError, TypeError):
+            pass
+
+        for band in self.bands:
+            if band.contains(value) or (name is not None and band.contains(name)):
+                if band.level == HEALTH_NOMINAL:
+                    return HEALTH_NOMINAL, ""
+                shown = name if name is not None else value
+                return (
+                    band.level,
+                    f"{self.field}={shown} in {_NAME_BY_LEVEL[band.level]} band",
+                )
+        shown = name if name is not None else value
+        return (
+            self.default_level,
+            f"{self.field}={shown} outside all bands",
+        )
+
+
+@dataclass
+class Expectation:
+    """Declarative definition of what a subsystem should look like on the bus."""
+
+    name: str
+    key_expr: str
+    inactive_after_s: float = 10.0
+    window_s: float = 10.0
+    publication_rate_hz: list[Band] = field(default_factory=list)
+    publication_rate_default_level: int = HEALTH_CRITICAL
+    content_rules: list[ContentRule] = field(default_factory=list)
+    require_liveliness: bool = True
+
+    def __post_init__(self) -> None:
+        self.publication_rate_hz.sort(
+            key=lambda b: _RANK.get(b.level, 99), reverse=True
+        )
+
+
+@dataclass
+class SubsystemState:
+    """Current per-subsystem status summary."""
+
+    name: str
+    level: int
+    detail: str
+
+
+class Evaluator:
+    """Per-expectation state: sample timestamps + latest payload.
+
+    `record(now, payload)` is called from the subscriber callback.
+    `evaluate(now)` produces a `SubsystemState` for publishing.
+    """
+
+    def __init__(self, expectation: Expectation, window_s: float | None = None):
+        self.expectation = expectation
+        # Rate window: explicit override > expectation.window_s.
+        self.window_s = window_s if window_s is not None else expectation.window_s
+        self._samples: Deque[float] = deque()
+        self._last_payload: Any = None
+        self._last_sample_at: float | None = None
+        # Set of key-expressions for which a liveliness token is currently
+        # present. The expectation is considered "alive" iff this is non-empty.
+        self.alive_sources: set[str] = set()
+
+    def set_alive(self, key: str) -> None:
+        self.alive_sources.add(key)
+
+    def set_dead(self, key: str) -> None:
+        self.alive_sources.discard(key)
+
+    @property
+    def is_alive(self) -> bool:
+        return bool(self.alive_sources)
+
+    def record(self, now: float, payload: Any = None) -> None:
+        self._samples.append(now)
+        self._last_sample_at = now
+        self._last_payload = payload
+        self._trim(now)
+
+    def _trim(self, now: float) -> None:
+        cutoff = now - self.window_s
+        while self._samples and self._samples[0] < cutoff:
+            self._samples.popleft()
+
+    def observed_rate_hz(self, now: float) -> float:
+        self._trim(now)
+        if not self._samples:
+            return 0.0
+        return len(self._samples) / self.window_s
+
+    def _publication_rate_level(self, now: float) -> tuple[int, str]:
+        exp = self.expectation
+        if not exp.publication_rate_hz:
+            return HEALTH_NOMINAL, ""
+        observed = self.observed_rate_hz(now)
+        for band in exp.publication_rate_hz:
+            if band.contains(observed):
+                if band.level == HEALTH_NOMINAL:
+                    return HEALTH_NOMINAL, ""
+                return (
+                    band.level,
+                    f"rate {observed:.2f}Hz in {_NAME_BY_LEVEL[band.level]} band",
+                )
+        return (
+            exp.publication_rate_default_level,
+            f"rate {observed:.2f}Hz outside all rate bands",
+        )
+
+    def evaluate(self, now: float) -> SubsystemState:
+        exp = self.expectation
+
+        # Liveliness gate: if required and no token is present → UNKNOWN.
+        if exp.require_liveliness and not self.is_alive:
+            return SubsystemState(
+                exp.name, HEALTH_UNKNOWN, "no liveliness token present"
+            )
+
+        # Alive (or liveliness not required) but no samples yet → INACTIVE.
+        if self._last_sample_at is None:
+            detail = (
+                "alive but no samples received yet"
+                if exp.require_liveliness
+                else "no samples received yet"
+            )
+            return SubsystemState(exp.name, HEALTH_INACTIVE, detail)
+
+        silence = now - self._last_sample_at
+        if silence > exp.inactive_after_s:
+            return SubsystemState(
+                exp.name,
+                HEALTH_INACTIVE,
+                f"silent for {silence:.1f}s (limit {exp.inactive_after_s}s)",
+            )
+
+        # Collect (level, detail) from rate check + every content rule
+        results: list[tuple[int, str]] = [self._publication_rate_level(now)]
+        for rule in exp.content_rules:
+            results.append(rule.evaluate(self._last_payload))
+
+        overall = worst(*(lv for lv, _ in results))
+        if overall == HEALTH_NOMINAL or overall == HEALTH_UNKNOWN:
+            return SubsystemState(exp.name, overall or HEALTH_NOMINAL, "ok")
+
+        # Build a detail string from all non-nominal contributors
+        details = [d for lv, d in results if lv != HEALTH_NOMINAL and d]
+        return SubsystemState(exp.name, overall, "; ".join(details) or "degraded")
+
+
+def evaluate_all(
+    evaluators: Iterable[Evaluator], now: float
+) -> tuple[int, list[SubsystemState]]:
+    """Aggregate all subsystems into an overall health level.
+
+    Overall level = worst (lowest-rank) of any non-UNKNOWN subsystem,
+    or UNKNOWN if the list is empty / all unknown.
+    """
+    states = [ev.evaluate(now) for ev in evaluators]
+    overall = worst(*(s.level for s in states))
+    return overall, states

--- a/connectors/entity_health/entity_health/evaluator.py
+++ b/connectors/entity_health/entity_health/evaluator.py
@@ -169,6 +169,7 @@ class SubsystemState:
     name: str
     level: int
     detail: str
+    measured_publication_rate_hz: float = 0.0
 
 
 class Evaluator:
@@ -236,11 +237,12 @@ class Evaluator:
 
     def evaluate(self, now: float) -> SubsystemState:
         exp = self.expectation
+        rate = self.observed_rate_hz(now)
 
         # Liveliness gate: if required and no token is present → UNKNOWN.
         if exp.require_liveliness and not self.is_alive:
             return SubsystemState(
-                exp.name, HEALTH_UNKNOWN, "no liveliness token present"
+                exp.name, HEALTH_UNKNOWN, "no liveliness token present", rate
             )
 
         # Alive (or liveliness not required) but no samples yet → INACTIVE.
@@ -250,7 +252,7 @@ class Evaluator:
                 if exp.require_liveliness
                 else "no samples received yet"
             )
-            return SubsystemState(exp.name, HEALTH_INACTIVE, detail)
+            return SubsystemState(exp.name, HEALTH_INACTIVE, detail, rate)
 
         silence = now - self._last_sample_at
         if silence > exp.inactive_after_s:
@@ -258,6 +260,7 @@ class Evaluator:
                 exp.name,
                 HEALTH_INACTIVE,
                 f"silent for {silence:.1f}s (limit {exp.inactive_after_s}s)",
+                rate,
             )
 
         # Collect (level, detail) from rate check + every content rule
@@ -267,11 +270,15 @@ class Evaluator:
 
         overall = worst(*(lv for lv, _ in results))
         if overall == HEALTH_NOMINAL or overall == HEALTH_UNKNOWN:
-            return SubsystemState(exp.name, overall or HEALTH_NOMINAL, "ok")
+            return SubsystemState(
+                exp.name, overall or HEALTH_NOMINAL, "ok", rate
+            )
 
         # Build a detail string from all non-nominal contributors
         details = [d for lv, d in results if lv != HEALTH_NOMINAL and d]
-        return SubsystemState(exp.name, overall, "; ".join(details) or "degraded")
+        return SubsystemState(
+            exp.name, overall, "; ".join(details) or "degraded", rate
+        )
 
 
 def evaluate_all(

--- a/connectors/entity_health/example-config.json
+++ b/connectors/entity_health/example-config.json
@@ -1,65 +1,74 @@
 {
   "publish_rate_hz": 0.1,
-  "expectations": [
+  "realm": "test-realm",
+  "entity_id": "test-vessel",
+  "sources": [
     {
-      "name": "gnss",
-      "key_expr": "test-realm/@v0/test-vessel/pubsub/location_fix/*",
-      "inactive_after_s": 3.0,
-      "publication_rate_hz": [
-        {"level": "NOMINAL",  "min": 8.0, "max": 12.0},
-        {"level": "DEGRADED", "min": 4.0, "max": 20.0}
-      ],
-      "publication_rate_default_level": "CRITICAL",
-      "content_rules": [
+      "name": "gnss_main",
+      "subjects": [
         {
-          "field": "latitude",
-          "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
-          "default_level": "CRITICAL"
+          "name": "location_fix",
+          "inactive_after_s": 3.0,
+          "publication_rate_hz": [
+            {"level": "NOMINAL",  "min": 8.0, "max": 12.0},
+            {"level": "DEGRADED", "min": 4.0, "max": 20.0}
+          ],
+          "publication_rate_default_level": "CRITICAL",
+          "content_rules": [
+            {
+              "field": "latitude",
+              "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
+              "default_level": "CRITICAL"
+            },
+            {
+              "field": "longitude",
+              "bands": [{"level": "NOMINAL", "min": -180, "max": 180}],
+              "default_level": "CRITICAL"
+            }
+          ]
         },
         {
-          "field": "longitude",
-          "bands": [{"level": "NOMINAL", "min": -180, "max": 180}],
-          "default_level": "CRITICAL"
+          "name": "location_fix_quality",
+          "inactive_after_s": 5.0,
+          "publication_rate_hz": [
+            {"level": "NOMINAL", "min": 0.5, "max": 5.0}
+          ],
+          "publication_rate_default_level": "DEGRADED",
+          "content_rules": [
+            {
+              "field": "fix_type",
+              "bands": [
+                {"level": "NOMINAL",  "equals": ["FIX_3D_RTK", "FIX_3D"]},
+                {"level": "DEGRADED", "equals": ["FIX_3D_DGPS", "FIX_2D", "GPS_DR"]},
+                {"level": "CRITICAL", "equals": ["INVALID", "FIX_NO", "UNKNOWN", "TIME_ONLY", "DR_ONLY"]}
+              ],
+              "default_level": "CRITICAL"
+            }
+          ]
         }
       ]
     },
     {
-      "name": "gnss_quality",
-      "key_expr": "test-realm/@v0/test-vessel/pubsub/location_fix_quality/*",
-      "inactive_after_s": 5.0,
-      "publication_rate_hz": [
-        {"level": "NOMINAL", "min": 0.5, "max": 5.0}
-      ],
-      "publication_rate_default_level": "DEGRADED",
-      "content_rules": [
+      "name": "battery_monitor",
+      "subjects": [
         {
-          "field": "fix_type",
-          "bands": [
-            {"level": "NOMINAL",  "equals": ["FIX_3D_RTK", "FIX_3D"]},
-            {"level": "DEGRADED", "equals": ["FIX_3D_DGPS", "FIX_2D", "GPS_DR"]},
-            {"level": "CRITICAL", "equals": ["INVALID", "FIX_NO", "UNKNOWN", "TIME_ONLY", "DR_ONLY"]}
+          "name": "battery_voltage_v",
+          "inactive_after_s": 5.0,
+          "publication_rate_hz": [
+            {"level": "NOMINAL", "min": 0.5, "max": 5.0}
           ],
-          "default_level": "CRITICAL"
-        }
-      ]
-    },
-    {
-      "name": "battery",
-      "key_expr": "test-realm/@v0/test-vessel/pubsub/battery_voltage_v/*",
-      "inactive_after_s": 5.0,
-      "publication_rate_hz": [
-        {"level": "NOMINAL", "min": 0.5, "max": 5.0}
-      ],
-      "publication_rate_default_level": "DEGRADED",
-      "content_rules": [
-        {
-          "field": "value",
-          "bands": [
-            {"level": "NOMINAL",  "min": 12.0, "max": 14.5},
-            {"level": "DEGRADED", "min": 11.0, "max": 15.0},
-            {"level": "CRITICAL", "min": 10.0, "max": 16.0}
-          ],
-          "default_level": "CRITICAL"
+          "publication_rate_default_level": "DEGRADED",
+          "content_rules": [
+            {
+              "field": "value",
+              "bands": [
+                {"level": "NOMINAL",  "min": 12.0, "max": 14.5},
+                {"level": "DEGRADED", "min": 11.0, "max": 15.0},
+                {"level": "CRITICAL", "min": 10.0, "max": 16.0}
+              ],
+              "default_level": "CRITICAL"
+            }
+          ]
         }
       ]
     }

--- a/connectors/entity_health/example-config.json
+++ b/connectors/entity_health/example-config.json
@@ -1,0 +1,67 @@
+{
+  "publish_rate_hz": 0.1,
+  "expectations": [
+    {
+      "name": "gnss",
+      "key_expr": "test-realm/@v0/test-vessel/pubsub/location_fix/*",
+      "inactive_after_s": 3.0,
+      "publication_rate_hz": [
+        {"level": "NOMINAL",  "min": 8.0, "max": 12.0},
+        {"level": "DEGRADED", "min": 4.0, "max": 20.0}
+      ],
+      "publication_rate_default_level": "CRITICAL",
+      "content_rules": [
+        {
+          "field": "latitude",
+          "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
+          "default_level": "CRITICAL"
+        },
+        {
+          "field": "longitude",
+          "bands": [{"level": "NOMINAL", "min": -180, "max": 180}],
+          "default_level": "CRITICAL"
+        }
+      ]
+    },
+    {
+      "name": "gnss_quality",
+      "key_expr": "test-realm/@v0/test-vessel/pubsub/location_fix_quality/*",
+      "inactive_after_s": 5.0,
+      "publication_rate_hz": [
+        {"level": "NOMINAL", "min": 0.5, "max": 5.0}
+      ],
+      "publication_rate_default_level": "DEGRADED",
+      "content_rules": [
+        {
+          "field": "fix_type",
+          "bands": [
+            {"level": "NOMINAL",  "equals": ["FIX_3D_RTK", "FIX_3D"]},
+            {"level": "DEGRADED", "equals": ["FIX_3D_DGPS", "FIX_2D", "GPS_DR"]},
+            {"level": "CRITICAL", "equals": ["INVALID", "FIX_NO", "UNKNOWN", "TIME_ONLY", "DR_ONLY"]}
+          ],
+          "default_level": "CRITICAL"
+        }
+      ]
+    },
+    {
+      "name": "battery",
+      "key_expr": "test-realm/@v0/test-vessel/pubsub/battery_voltage_v/*",
+      "inactive_after_s": 5.0,
+      "publication_rate_hz": [
+        {"level": "NOMINAL", "min": 0.5, "max": 5.0}
+      ],
+      "publication_rate_default_level": "DEGRADED",
+      "content_rules": [
+        {
+          "field": "value",
+          "bands": [
+            {"level": "NOMINAL",  "min": 12.0, "max": 14.5},
+            {"level": "DEGRADED", "min": 11.0, "max": 15.0},
+            {"level": "CRITICAL", "min": 10.0, "max": 16.0}
+          ],
+          "default_level": "CRITICAL"
+        }
+      ]
+    }
+  ]
+}

--- a/connectors/entity_health/pyproject.toml
+++ b/connectors/entity_health/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "keelson-connector-entity-health"
+version = "0.0.0"
+description = "Entity health monitor connector for Keelson"
+requires-python = ">=3.11"
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.packages.find]
+include = ["entity_health*"]
+
+[tool.uv.sources]
+keelson = { workspace = true }
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/connectors/entity_health/requirements.txt
+++ b/connectors/entity_health/requirements.txt
@@ -1,0 +1,2 @@
+keelson
+jsonschema>=4.20.0

--- a/connectors/entity_health/tests/conftest.py
+++ b/connectors/entity_health/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared fixtures for entity_health connector tests."""
+
+import importlib.util
+import pathlib
+import sys
+from importlib.machinery import SourceFileLoader
+
+import pytest
+
+# Make the entity_health package importable for unit tests.
+PKG_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PKG_ROOT))
+
+BIN_ROOT = PKG_ROOT / "bin"
+
+
+def _load_bin_module():
+    path = BIN_ROOT / "entity_health2keelson.py"
+    loader = SourceFileLoader("entity_health2keelson", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def entity_health_module():
+    """Load the bin/ entry point as an importable module."""
+    return _load_bin_module()
+
+
+@pytest.fixture(autouse=True)
+def clear_module_state():
+    """Clear module-level state between tests."""
+    try:
+        mod = _load_bin_module()
+    except Exception:
+        # Module may fail to import if generated protos are missing;
+        # unit tests for the pure evaluator don't need it.
+        yield
+        return
+
+    mod.PUBLISHERS.clear()
+    mod.SUBSCRIBERS.clear()
+    mod.LIVELINESS_SUBSCRIBERS.clear()
+    mod.EVALUATORS.clear()
+    mod.CONFIG.clear()
+    mod.SESSION = None
+    yield
+    mod.PUBLISHERS.clear()
+    mod.SUBSCRIBERS.clear()
+    mod.LIVELINESS_SUBSCRIBERS.clear()
+    mod.EVALUATORS.clear()
+    mod.CONFIG.clear()
+    mod.SESSION = None

--- a/connectors/entity_health/tests/test_entity_health_cli.py
+++ b/connectors/entity_health/tests/test_entity_health_cli.py
@@ -36,3 +36,7 @@ class TestEntityHealthCli:
             ],
         )
         assert result.returncode != 0
+        # The connector logs "Config file is not valid JSON" and exits 1 — pin
+        # that path so an unrelated import/startup error doesn't pass silently.
+        combined = (result.stderr + result.stdout).lower()
+        assert "json" in combined, f"expected JSON error in output, got: {combined!r}"

--- a/connectors/entity_health/tests/test_entity_health_cli.py
+++ b/connectors/entity_health/tests/test_entity_health_cli.py
@@ -1,0 +1,38 @@
+"""CLI smoke tests for the entity_health connector."""
+
+
+class TestEntityHealthCli:
+    def test_help_output(self, run_connector):
+        result = run_connector("entity_health", "entity_health2keelson", ["--help"])
+        assert result.returncode == 0
+        assert "entity_health" in result.stdout
+        assert "--config" in result.stdout
+        assert "--realm" in result.stdout
+
+    def test_requires_config(self, run_connector):
+        result = run_connector(
+            "entity_health",
+            "entity_health2keelson",
+            ["--realm", "r", "--entity-id", "e", "--source-id", "s"],
+        )
+        assert result.returncode != 0
+        assert "required" in result.stderr.lower() or "config" in result.stderr.lower()
+
+    def test_invalid_config_file(self, run_connector, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        result = run_connector(
+            "entity_health",
+            "entity_health2keelson",
+            [
+                "--realm",
+                "r",
+                "--entity-id",
+                "e",
+                "--source-id",
+                "s",
+                "--config",
+                str(bad),
+            ],
+        )
+        assert result.returncode != 0

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -107,7 +107,7 @@ class _HealthCollector:
 
 
 def _subsystem(msg: EntityHealth, name: str):
-    for s in msg.subsystems:
+    for s in msg.sources:
         if s.name == name:
             return s
     return None
@@ -220,7 +220,7 @@ def test_entity_health_full_lifecycle(
         assert loa.detail == "ok", f"loa detail: {loa.detail!r}"
         assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
         assert msg.rate_hz == pytest.approx(5.0)
-        assert {s.name for s in msg.subsystems} == {"loa", "boa"}
+        assert {s.name for s in msg.sources} == {"loa", "boa"}
 
         # === Phase 2: degrade only loa → entity DEGRADED, boa still NOMINAL ===
         _set_config(

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -10,6 +10,7 @@ process opens its own Zenoh session to:
 """
 
 import json
+import logging
 import threading
 import time
 from pathlib import Path
@@ -38,8 +39,6 @@ PLATFORM_SOURCE_ID = "geometry"
 
 HEALTH_KEY = construct_pubsub_key(REALM, ENTITY_ID, "entity_health", HEALTH_SOURCE_ID)
 SET_CONFIG_KEY = construct_rpc_key(REALM, ENTITY_ID, "set_config", HEALTH_SOURCE_ID)
-LOA_KEY = "test-realm/@v0/test-vessel/pubsub/length_over_all_m/*"
-BOA_KEY = "test-realm/@v0/test-vessel/pubsub/breadth_over_all_m/*"
 
 
 # A "calm" band wide enough to keep the platform's ~1 Hz publishing in NOMINAL.
@@ -50,35 +49,45 @@ _CALM_BANDS = [
 
 
 def _make_health_config(
-    loa_bands: list[dict] = _CALM_BANDS,
-    boa_bands: list[dict] = _CALM_BANDS,
+    loa_bands: list[dict] | None = None,
+    boa_bands: list[dict] | None = None,
     inactive_after_s: float = 2.0,
     window_s: float = 2.0,
 ) -> dict:
-    """Two-subsystem config so we can verify worst-wins aggregation."""
+    """One source, two subjects — exercises per-source aggregation."""
+    if loa_bands is None:
+        loa_bands = _CALM_BANDS
+    if boa_bands is None:
+        boa_bands = _CALM_BANDS
     return {
         "publish_rate_hz": 5.0,
-        "expectations": [
+        "sources": [
             {
-                "name": "loa",
-                "key_expr": LOA_KEY,
-                "inactive_after_s": inactive_after_s,
-                "window_s": window_s,
-                "publication_rate_hz": loa_bands,
-                "publication_rate_default_level": "CRITICAL",
-                "require_liveliness": True,
-            },
-            {
-                "name": "boa",
-                "key_expr": BOA_KEY,
-                "inactive_after_s": inactive_after_s,
-                "window_s": window_s,
-                "publication_rate_hz": boa_bands,
-                "publication_rate_default_level": "CRITICAL",
-                "require_liveliness": True,
+                "name": PLATFORM_SOURCE_ID,
+                "subjects": [
+                    {
+                        "name": "length_over_all_m",
+                        "inactive_after_s": inactive_after_s,
+                        "window_s": window_s,
+                        "publication_rate_hz": loa_bands,
+                        "publication_rate_default_level": "CRITICAL",
+                        "require_liveliness": True,
+                    },
+                    {
+                        "name": "breadth_over_all_m",
+                        "inactive_after_s": inactive_after_s,
+                        "window_s": window_s,
+                        "publication_rate_hz": boa_bands,
+                        "publication_rate_default_level": "CRITICAL",
+                        "require_liveliness": True,
+                    },
+                ],
             },
         ],
     }
+
+
+_logger = logging.getLogger(__name__)
 
 
 class _HealthCollector:
@@ -94,7 +103,9 @@ class _HealthCollector:
             msg.ParseFromString(payload)
             self.messages.append(msg)
         except Exception:
-            pass
+            # Don't let a malformed sample tank the test silently — surface it
+            # so a "no message received" timeout becomes a parse traceback.
+            _logger.exception("failed to decode EntityHealth sample")
 
     def clear(self) -> None:
         self.messages.clear()
@@ -109,9 +120,21 @@ class _HealthCollector:
         return self.messages[-1] if self.messages else None
 
 
-def _subsystem(msg: EntityHealth, name: str):
-    for s in msg.subjects:
-        if s.name == name:
+def _source(msg: EntityHealth, source_name: str):
+    for s in msg.sources:
+        if s.name == source_name:
+            return s
+    return None
+
+
+def _subject(
+    msg: EntityHealth, subject_name: str, source_name: str = PLATFORM_SOURCE_ID
+):
+    src = _source(msg, source_name)
+    if src is None:
+        return None
+    for s in src.subjects:
+        if s.name == subject_name:
             return s
     return None
 
@@ -159,6 +182,9 @@ def test_entity_health_full_lifecycle(
         listen=[zenoh_endpoints["listen"]],
     )
     session = zenoh.open(test_conf)
+    sub = None
+    platform = None
+    health = None
 
     try:
         collector = _HealthCollector()
@@ -205,23 +231,33 @@ def test_entity_health_full_lifecycle(
         health.start()
 
         # === Phase 1: both subsystems NOMINAL → entity NOMINAL ===
-        time.sleep(4.0)
+        # Generous timeout: cold-start (process spawn + Zenoh discovery) +
+        # window_s=2 + a couple of ~1 Hz publish ticks to fill the window.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "boa") is not None
-            and _subsystem(m, "loa").level == HEALTH_NOMINAL
-            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "breadth_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_NOMINAL
+            and _subject(m, "breadth_over_all_m").level == HEALTH_NOMINAL,
+            timeout=12.0,
         )
         assert msg is not None, "no EntityHealth received"
         assert msg.level == HEALTH_NOMINAL
-        loa = _subsystem(msg, "loa")
-        boa = _subsystem(msg, "boa")
-        assert loa.name == "loa"
-        assert boa.name == "boa"
+        loa = _subject(msg, "length_over_all_m")
+        boa = _subject(msg, "breadth_over_all_m")
+        assert loa.name == "length_over_all_m"
+        assert boa.name == "breadth_over_all_m"
         assert loa.level == HEALTH_NOMINAL
         assert boa.level == HEALTH_NOMINAL
         assert msg.rate_hz == pytest.approx(5.0)
-        assert {s.name for s in msg.subjects} == {"loa", "boa"}
+        # Both subjects must hang off the platform source — there is exactly one
+        # SourceHealth, named after the publisher's source-id.
+        assert [s.name for s in msg.sources] == [PLATFORM_SOURCE_ID]
+        assert {s.name for s in msg.sources[0].subjects} == {
+            "length_over_all_m",
+            "breadth_over_all_m",
+        }
+        # Source-level rollup is the worst of its subjects (NOMINAL here).
+        assert msg.sources[0].level == HEALTH_NOMINAL
         # checks[] should carry the per-check NOMINAL results
         assert {c.name for c in loa.checks} == {"activity", "publication_rate"}
         assert all(c.level == HEALTH_NOMINAL for c in loa.checks)
@@ -236,15 +272,16 @@ def test_entity_health_full_lifecycle(
                 ],
             ),
         )
-        time.sleep(3.0)
+        # window_s=2 + a publish tick at publish_rate_hz=5 → effects visible
+        # within ~3s; default 6s timeout in wait_for absorbs scheduler jitter.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_DEGRADED
-            and _subsystem(m, "boa") is not None
-            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_DEGRADED
+            and _subject(m, "breadth_over_all_m") is not None
+            and _subject(m, "breadth_over_all_m").level == HEALTH_NOMINAL
         )
-        loa = _subsystem(msg, "loa")
-        boa = _subsystem(msg, "boa")
+        loa = _subject(msg, "length_over_all_m")
+        boa = _subject(msg, "breadth_over_all_m")
         assert loa.level == HEALTH_DEGRADED, loa
         assert boa.level == HEALTH_NOMINAL, boa
         loa_rate = next(c for c in loa.checks if c.name == "publication_rate")
@@ -269,15 +306,15 @@ def test_entity_health_full_lifecycle(
                 ],
             ),
         )
-        time.sleep(3.0)
+        # Same budget as phase 2 — only the band thresholds shifted.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_CRITICAL
-            and _subsystem(m, "boa") is not None
-            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_CRITICAL
+            and _subject(m, "breadth_over_all_m") is not None
+            and _subject(m, "breadth_over_all_m").level == HEALTH_NOMINAL
         )
-        loa = _subsystem(msg, "loa")
-        boa = _subsystem(msg, "boa")
+        loa = _subject(msg, "length_over_all_m")
+        boa = _subject(msg, "breadth_over_all_m")
         assert loa.level == HEALTH_CRITICAL, loa
         assert boa.level == HEALTH_NOMINAL, boa
         loa_rate = next(c for c in loa.checks if c.name == "publication_rate")
@@ -291,17 +328,17 @@ def test_entity_health_full_lifecycle(
         # === Phase 4: stop platform → both subsystems lose liveliness → UNKNOWN ===
         collector.clear()
         platform.stop()
+        # Liveliness drop propagates almost immediately, but inactive_after_s=2
+        # plus Zenoh's liveliness eviction adds slack — 8s is comfortable.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_UNKNOWN
-            and _subsystem(m, "boa") is not None
-            and _subsystem(m, "boa").level == HEALTH_UNKNOWN,
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_UNKNOWN
+            and _subject(m, "breadth_over_all_m") is not None
+            and _subject(m, "breadth_over_all_m").level == HEALTH_UNKNOWN,
             timeout=8.0,
         )
-        loa = _subsystem(msg, "loa")
-        boa = _subsystem(msg, "boa")
-        sub.undeclare()
-        health.stop()
+        loa = _subject(msg, "length_over_all_m")
+        boa = _subject(msg, "breadth_over_all_m")
         assert loa.level == HEALTH_UNKNOWN, f"expected loa UNKNOWN, got {loa.level}"
         assert boa.level == HEALTH_UNKNOWN, f"expected boa UNKNOWN, got {boa.level}"
         assert (
@@ -311,6 +348,12 @@ def test_entity_health_full_lifecycle(
         assert list(loa.checks) == []
         assert list(boa.checks) == []
     finally:
+        if sub is not None:
+            sub.undeclare()
+        if health is not None:
+            health.stop()
+        if platform is not None:
+            platform.stop()
         session.close()
 
 
@@ -354,6 +397,10 @@ def test_measured_publication_rate_tracks_publisher(
         listen=[zenoh_endpoints["listen"]],
     )
     session = zenoh.open(test_conf)
+    sub = None
+    platform_fast = None
+    platform_slow = None
+    health = None
 
     def _platform(interval_s: int):
         return connector_process_factory(
@@ -404,14 +451,14 @@ def test_measured_publication_rate_tracks_publisher(
         # Wait for a NOMINAL message where the measured rate has stabilised
         # near 1 Hz (window_s=3 → ~3 samples → 1.0 Hz).
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_NOMINAL
-            and _subsystem(m, "loa").measured_publication_rate_hz >= 0.8,
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_NOMINAL
+            and _subject(m, "length_over_all_m").measured_publication_rate_hz >= 0.8,
             timeout=10.0,
         )
         assert msg is not None, "no EntityHealth received in phase A"
-        loa_fast = _subsystem(msg, "loa")
-        boa_fast = _subsystem(msg, "boa")
+        loa_fast = _subject(msg, "length_over_all_m")
+        boa_fast = _subject(msg, "breadth_over_all_m")
         assert (
             loa_fast.measured_publication_rate_hz > 0.0
         ), "measured_publication_rate_hz should be non-zero when samples are flowing"
@@ -431,18 +478,20 @@ def test_measured_publication_rate_tracks_publisher(
         # The window must drain the 1 Hz samples (3s window) and refill with
         # 0.5 Hz samples, so we allow generous time. We accept the new rate
         # as soon as it has clearly dropped and is positive.
+        # Drain old 1 Hz samples from the 3s window + refill with 0.5 Hz —
+        # worst case ~3s drain + 2 fresh ticks ≈ 7s; 15s gives ample slack.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_NOMINAL
-            and 0.0 < _subsystem(m, "loa").measured_publication_rate_hz
-            and _subsystem(m, "loa").measured_publication_rate_hz < fast_rate * 0.8,
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_NOMINAL
+            and 0.0 < _subject(m, "length_over_all_m").measured_publication_rate_hz
+            and _subject(m, "length_over_all_m").measured_publication_rate_hz
+            < fast_rate * 0.8,
             timeout=15.0,
         )
-        sub.undeclare()
         assert (
             msg is not None
         ), "expected a NOMINAL message with a reduced measured rate after slowing the publisher"
-        loa_slow = _subsystem(msg, "loa")
+        loa_slow = _subject(msg, "length_over_all_m")
         assert (
             loa_slow.measured_publication_rate_hz < fast_rate
         ), f"slow rate {loa_slow.measured_publication_rate_hz} should be < fast rate {fast_rate}"
@@ -450,6 +499,13 @@ def test_measured_publication_rate_tracks_publisher(
             0.5, abs=0.4
         ), f"expected loa rate ~0.5 Hz after slowing publisher, got {loa_slow.measured_publication_rate_hz}"
     finally:
+        if sub is not None:
+            sub.undeclare()
+        if health is not None:
+            health.stop()
+        for p in (platform_fast, platform_slow):
+            if p is not None:
+                p.stop()
         session.close()
 
 
@@ -487,6 +543,9 @@ def test_source_health_checks_field_published(
         listen=[zenoh_endpoints["listen"]],
     )
     session = zenoh.open(test_conf)
+    sub = None
+    platform = None
+    health = None
 
     try:
         collector = _HealthCollector()
@@ -531,13 +590,14 @@ def test_source_health_checks_field_published(
         health.start()
 
         # --- NOMINAL: structured checks[] with publication_rate at NOMINAL ---
+        # Cold-start budget: spawn + Zenoh discovery + window_s=2 fill.
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_NOMINAL,
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_NOMINAL,
             timeout=8.0,
         )
         assert msg is not None, "no NOMINAL EntityHealth received"
-        loa = _subsystem(msg, "loa")
+        loa = _subject(msg, "length_over_all_m")
         rate_check = next((c for c in loa.checks if c.name == "publication_rate"), None)
         assert (
             rate_check is not None
@@ -560,28 +620,31 @@ def test_source_health_checks_field_published(
             ),
         )
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "loa") is not None
-            and _subsystem(m, "loa").level == HEALTH_DEGRADED,
+            lambda m: _subject(m, "length_over_all_m") is not None
+            and _subject(m, "length_over_all_m").level == HEALTH_DEGRADED,
             timeout=8.0,
         )
-        sub.undeclare()
         assert (
             msg is not None
         ), "no DEGRADED EntityHealth received after flipping rate band"
-        loa = _subsystem(msg, "loa")
+        loa = _subject(msg, "length_over_all_m")
         rate_check = next((c for c in loa.checks if c.name == "publication_rate"), None)
         assert rate_check is not None
         assert rate_check.level == HEALTH_DEGRADED
         assert "DEGRADED" in rate_check.detail
         assert "rate" in rate_check.detail
     finally:
+        if sub is not None:
+            sub.undeclare()
+        if health is not None:
+            health.stop()
+        if platform is not None:
+            platform.stop()
         session.close()
 
 
 # --- gnss + gnss_quality content-rule e2e -------------------------------
 
-GNSS_SUBJECT_KEY = "test-realm/@v0/test-vessel/pubsub/location_fix/*"
-QUAL_SUBJECT_KEY = "test-realm/@v0/test-vessel/pubsub/location_fix_quality/*"
 GNSS_PUB_SOURCE = "gnss-mock"
 GNSS_FIX_KEY = construct_pubsub_key(REALM, ENTITY_ID, "location_fix", GNSS_PUB_SOURCE)
 GNSS_QUAL_KEY = construct_pubsub_key(
@@ -590,7 +653,7 @@ GNSS_QUAL_KEY = construct_pubsub_key(
 
 
 def _gnss_health_config() -> dict:
-    """Two expectations mirroring example-config.json's gnss + gnss_quality.
+    """One source publishing two subjects (location_fix + location_fix_quality).
 
     `require_liveliness=False` so the test publisher (a thread, not a real
     connector) doesn't need to declare liveliness tokens. Rate bands are
@@ -601,60 +664,69 @@ def _gnss_health_config() -> dict:
     rate_band = [{"level": "NOMINAL", "min": 1.0, "max": 50.0}]
     return {
         "publish_rate_hz": 5.0,
-        "expectations": [
+        "sources": [
             {
-                "name": "gnss",
-                "key_expr": GNSS_SUBJECT_KEY,
-                "inactive_after_s": 5.0,
-                "window_s": 2.0,
-                "publication_rate_hz": rate_band,
-                "publication_rate_default_level": "CRITICAL",
-                "require_liveliness": False,
-                "content_rules": [
+                "name": GNSS_PUB_SOURCE,
+                "subjects": [
                     {
-                        "field": "latitude",
-                        "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
-                        "default_level": "CRITICAL",
-                    },
-                    {
-                        "field": "longitude",
-                        "bands": [{"level": "NOMINAL", "min": -180, "max": 180}],
-                        "default_level": "CRITICAL",
-                    },
-                ],
-            },
-            {
-                "name": "gnss_quality",
-                "key_expr": QUAL_SUBJECT_KEY,
-                "inactive_after_s": 5.0,
-                "window_s": 2.0,
-                "publication_rate_hz": rate_band,
-                "publication_rate_default_level": "CRITICAL",
-                "require_liveliness": False,
-                "content_rules": [
-                    {
-                        "field": "fix_type",
-                        "bands": [
+                        "name": "location_fix",
+                        "inactive_after_s": 5.0,
+                        "window_s": 2.0,
+                        "publication_rate_hz": rate_band,
+                        "publication_rate_default_level": "CRITICAL",
+                        "require_liveliness": False,
+                        "content_rules": [
                             {
-                                "level": "NOMINAL",
-                                "equals": ["FIX_3D_RTK", "FIX_3D"],
+                                "field": "latitude",
+                                "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
+                                "default_level": "CRITICAL",
                             },
                             {
-                                "level": "DEGRADED",
-                                "equals": ["FIX_3D_DGPS", "FIX_2D", "GPS_DR"],
-                            },
-                            {
-                                "level": "CRITICAL",
-                                "equals": [
-                                    "INVALID",
-                                    "FIX_NO",
-                                    "UNKNOWN",
-                                    "TIME_ONLY",
-                                    "DR_ONLY",
+                                "field": "longitude",
+                                "bands": [
+                                    {"level": "NOMINAL", "min": -180, "max": 180}
                                 ],
+                                "default_level": "CRITICAL",
                             },
                         ],
-                        "default_level": "CRITICAL",
+                    },
+                    {
+                        "name": "location_fix_quality",
+                        "inactive_after_s": 5.0,
+                        "window_s": 2.0,
+                        "publication_rate_hz": rate_band,
+                        "publication_rate_default_level": "CRITICAL",
+                        "require_liveliness": False,
+                        "content_rules": [
+                            {
+                                "field": "fix_type",
+                                "bands": [
+                                    {
+                                        "level": "NOMINAL",
+                                        "equals": ["FIX_3D_RTK", "FIX_3D"],
+                                    },
+                                    {
+                                        "level": "DEGRADED",
+                                        "equals": [
+                                            "FIX_3D_DGPS",
+                                            "FIX_2D",
+                                            "GPS_DR",
+                                        ],
+                                    },
+                                    {
+                                        "level": "CRITICAL",
+                                        "equals": [
+                                            "INVALID",
+                                            "FIX_NO",
+                                            "UNKNOWN",
+                                            "TIME_ONLY",
+                                            "DR_ONLY",
+                                        ],
+                                    },
+                                ],
+                                "default_level": "CRITICAL",
+                            },
+                        ],
                     },
                 ],
             },
@@ -710,6 +782,9 @@ def test_gnss_content_rules_with_structured_checks(
     pub_thread = threading.Thread(target=publish_loop, daemon=True)
     pub_thread.start()
 
+    sub = None
+    health = None
+
     try:
         collector = _HealthCollector()
         sub = session.declare_subscriber(HEALTH_KEY, collector)
@@ -734,16 +809,17 @@ def test_gnss_content_rules_with_structured_checks(
 
         # === Phase 1: All NOMINAL ===
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "gnss") is not None
-            and _subsystem(m, "gnss").level == HEALTH_NOMINAL
-            and _subsystem(m, "gnss_quality") is not None
-            and _subsystem(m, "gnss_quality").level == HEALTH_NOMINAL,
+            lambda m: _subject(m, "location_fix", GNSS_PUB_SOURCE) is not None
+            and _subject(m, "location_fix", GNSS_PUB_SOURCE).level == HEALTH_NOMINAL
+            and _subject(m, "location_fix_quality", GNSS_PUB_SOURCE) is not None
+            and _subject(m, "location_fix_quality", GNSS_PUB_SOURCE).level
+            == HEALTH_NOMINAL,
             timeout=10.0,
         )
         assert msg is not None, "no all-NOMINAL EntityHealth received"
         assert msg.level == HEALTH_NOMINAL
-        gnss = _subsystem(msg, "gnss")
-        qual = _subsystem(msg, "gnss_quality")
+        gnss = _subject(msg, "location_fix", GNSS_PUB_SOURCE)
+        qual = _subject(msg, "location_fix_quality", GNSS_PUB_SOURCE)
         assert {c.name for c in gnss.checks} == {
             "activity",
             "publication_rate",
@@ -764,12 +840,13 @@ def test_gnss_content_rules_with_structured_checks(
         with state_lock:
             state["fix"] = LocationFixQuality.FIX_3D_DGPS
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "gnss_quality") is not None
-            and _subsystem(m, "gnss_quality").level == HEALTH_DEGRADED,
+            lambda m: _subject(m, "location_fix_quality", GNSS_PUB_SOURCE) is not None
+            and _subject(m, "location_fix_quality", GNSS_PUB_SOURCE).level
+            == HEALTH_DEGRADED,
             timeout=10.0,
         )
-        gnss = _subsystem(msg, "gnss")
-        qual = _subsystem(msg, "gnss_quality")
+        gnss = _subject(msg, "location_fix", GNSS_PUB_SOURCE)
+        qual = _subject(msg, "location_fix_quality", GNSS_PUB_SOURCE)
         assert (
             gnss.level == HEALTH_NOMINAL
         ), "gnss should be unaffected by fix_type change"
@@ -790,15 +867,15 @@ def test_gnss_content_rules_with_structured_checks(
         with state_lock:
             state["lat"] = 200.0  # outside [-90, 90]
         msg = collector.wait_for(
-            lambda m: _subsystem(m, "gnss") is not None
-            and _subsystem(m, "gnss").level == HEALTH_CRITICAL
-            and _subsystem(m, "gnss_quality") is not None
-            and _subsystem(m, "gnss_quality").level == HEALTH_DEGRADED,
+            lambda m: _subject(m, "location_fix", GNSS_PUB_SOURCE) is not None
+            and _subject(m, "location_fix", GNSS_PUB_SOURCE).level == HEALTH_CRITICAL
+            and _subject(m, "location_fix_quality", GNSS_PUB_SOURCE) is not None
+            and _subject(m, "location_fix_quality", GNSS_PUB_SOURCE).level
+            == HEALTH_DEGRADED,
             timeout=10.0,
         )
-        sub.undeclare()
-        gnss = _subsystem(msg, "gnss")
-        qual = _subsystem(msg, "gnss_quality")
+        gnss = _subject(msg, "location_fix", GNSS_PUB_SOURCE)
+        qual = _subject(msg, "location_fix_quality", GNSS_PUB_SOURCE)
         assert gnss.level == HEALTH_CRITICAL
         lat_check = next(c for c in gnss.checks if c.name == "latitude")
         lon_check = next(c for c in gnss.checks if c.name == "longitude")
@@ -816,9 +893,14 @@ def test_gnss_content_rules_with_structured_checks(
         # Entity reflects worst-of (CRITICAL > DEGRADED)
         assert msg.level == HEALTH_CRITICAL
     finally:
+        # Stop the publisher thread first so undeclare doesn't race the loop.
         with state_lock:
             state["stop"] = True
         pub_thread.join(timeout=2.0)
+        if sub is not None:
+            sub.undeclare()
+        if health is not None:
+            health.stop()
         fix_pub.undeclare()
         qual_pub.undeclare()
         session.close()

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -10,6 +10,7 @@ process opens its own Zenoh session to:
 """
 
 import json
+import threading
 import time
 from pathlib import Path
 
@@ -17,7 +18,7 @@ import pytest
 import zenoh
 
 import keelson
-from keelson import construct_pubsub_key, construct_rpc_key
+from keelson import construct_pubsub_key, construct_rpc_key, enclose
 from keelson.payloads.EntityHealth_pb2 import (
     EntityHealth,
     HEALTH_CRITICAL,
@@ -25,6 +26,8 @@ from keelson.payloads.EntityHealth_pb2 import (
     HEALTH_NOMINAL,
     HEALTH_UNKNOWN,
 )
+from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.scaffolding import create_zenoh_config
 
 
@@ -217,10 +220,11 @@ def test_entity_health_full_lifecycle(
         assert boa.name == "boa"
         assert loa.level == HEALTH_NOMINAL
         assert boa.level == HEALTH_NOMINAL
-        assert loa.detail == "ok", f"loa detail: {loa.detail!r}"
-        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
         assert msg.rate_hz == pytest.approx(5.0)
         assert {s.name for s in msg.sources} == {"loa", "boa"}
+        # checks[] should carry the per-check NOMINAL results
+        assert {c.name for c in loa.checks} == {"activity", "publication_rate"}
+        assert all(c.level == HEALTH_NOMINAL for c in loa.checks)
 
         # === Phase 2: degrade only loa → entity DEGRADED, boa still NOMINAL ===
         _set_config(
@@ -243,11 +247,14 @@ def test_entity_health_full_lifecycle(
         boa = _subsystem(msg, "boa")
         assert loa.level == HEALTH_DEGRADED, loa
         assert boa.level == HEALTH_NOMINAL, boa
+        loa_rate = next(c for c in loa.checks if c.name == "publication_rate")
         assert (
-            "DEGRADED" in loa.detail
-        ), f"expected DEGRADED-band detail on loa, got {loa.detail!r}"
-        assert "rate" in loa.detail, f"loa detail: {loa.detail!r}"
-        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
+            loa_rate.level == HEALTH_DEGRADED
+        ), f"expected DEGRADED publication_rate on loa, got {loa_rate}"
+        assert (
+            "DEGRADED" in loa_rate.detail
+        ), f"expected DEGRADED-band detail on loa rate check, got {loa_rate.detail!r}"
+        assert "rate" in loa_rate.detail, f"loa rate check detail: {loa_rate.detail!r}"
         assert (
             msg.level == HEALTH_DEGRADED
         ), f"entity should reflect worst subsystem (DEGRADED), got {msg.level}"
@@ -273,10 +280,10 @@ def test_entity_health_full_lifecycle(
         boa = _subsystem(msg, "boa")
         assert loa.level == HEALTH_CRITICAL, loa
         assert boa.level == HEALTH_NOMINAL, boa
+        loa_rate = next(c for c in loa.checks if c.name == "publication_rate")
         assert (
-            "outside all rate bands" in loa.detail
-        ), f"expected fall-through detail on loa, got {loa.detail!r}"
-        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
+            "outside all rate bands" in loa_rate.detail
+        ), f"expected fall-through detail on loa rate check, got {loa_rate.detail!r}"
         assert (
             msg.level == HEALTH_CRITICAL
         ), f"entity should reflect worst subsystem (CRITICAL), got {msg.level}"
@@ -295,17 +302,14 @@ def test_entity_health_full_lifecycle(
         boa = _subsystem(msg, "boa")
         sub.undeclare()
         health.stop()
-        assert (
-            loa.level == HEALTH_UNKNOWN
-        ), f"expected loa UNKNOWN, got {loa.level}: {loa.detail}"
-        assert (
-            boa.level == HEALTH_UNKNOWN
-        ), f"expected boa UNKNOWN, got {boa.level}: {boa.detail}"
+        assert loa.level == HEALTH_UNKNOWN, f"expected loa UNKNOWN, got {loa.level}"
+        assert boa.level == HEALTH_UNKNOWN, f"expected boa UNKNOWN, got {boa.level}"
         assert (
             msg.level == HEALTH_UNKNOWN
         ), f"entity should be UNKNOWN when all subsystems are UNKNOWN, got {msg.level}"
-        assert "liveliness" in loa.detail
-        assert "liveliness" in boa.detail
+        # Liveliness gate emits no checks — UNKNOWN at the source level says it all
+        assert list(loa.checks) == []
+        assert list(boa.checks) == []
     finally:
         session.close()
 
@@ -356,12 +360,18 @@ def test_measured_publication_rate_tracks_publisher(
             "platform",
             "platform-geometry",
             [
-                "--realm", REALM,
-                "--entity-id", ENTITY_ID,
-                "--source-id", PLATFORM_SOURCE_ID,
-                "--config", str(platform_config_path),
-                "--interval", str(interval_s),
-                "--connect", zenoh_endpoints["connect"],
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                PLATFORM_SOURCE_ID,
+                "--config",
+                str(platform_config_path),
+                "--interval",
+                str(interval_s),
+                "--connect",
+                zenoh_endpoints["connect"],
             ],
         )
 
@@ -377,11 +387,16 @@ def test_measured_publication_rate_tracks_publisher(
             "entity_health",
             "entity_health2keelson",
             [
-                "--realm", REALM,
-                "--entity-id", ENTITY_ID,
-                "--source-id", HEALTH_SOURCE_ID,
-                "--config", str(config_path),
-                "--connect", zenoh_endpoints["connect"],
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                HEALTH_SOURCE_ID,
+                "--config",
+                str(config_path),
+                "--connect",
+                zenoh_endpoints["connect"],
             ],
         )
         health.start()
@@ -397,15 +412,15 @@ def test_measured_publication_rate_tracks_publisher(
         assert msg is not None, "no EntityHealth received in phase A"
         loa_fast = _subsystem(msg, "loa")
         boa_fast = _subsystem(msg, "boa")
-        assert loa_fast.measured_publication_rate_hz > 0.0, (
-            "measured_publication_rate_hz should be non-zero when samples are flowing"
-        )
-        assert loa_fast.measured_publication_rate_hz == pytest.approx(1.0, abs=0.5), (
-            f"expected loa rate ~1.0 Hz, got {loa_fast.measured_publication_rate_hz}"
-        )
-        assert boa_fast.measured_publication_rate_hz == pytest.approx(1.0, abs=0.5), (
-            f"expected boa rate ~1.0 Hz, got {boa_fast.measured_publication_rate_hz}"
-        )
+        assert (
+            loa_fast.measured_publication_rate_hz > 0.0
+        ), "measured_publication_rate_hz should be non-zero when samples are flowing"
+        assert loa_fast.measured_publication_rate_hz == pytest.approx(
+            1.0, abs=0.5
+        ), f"expected loa rate ~1.0 Hz, got {loa_fast.measured_publication_rate_hz}"
+        assert boa_fast.measured_publication_rate_hz == pytest.approx(
+            1.0, abs=0.5
+        ), f"expected boa rate ~1.0 Hz, got {boa_fast.measured_publication_rate_hz}"
         fast_rate = loa_fast.measured_publication_rate_hz
 
         # --- Phase B: swap to 0.5 Hz publisher ---
@@ -424,15 +439,386 @@ def test_measured_publication_rate_tracks_publisher(
             timeout=15.0,
         )
         sub.undeclare()
-        assert msg is not None, (
-            "expected a NOMINAL message with a reduced measured rate after slowing the publisher"
-        )
+        assert (
+            msg is not None
+        ), "expected a NOMINAL message with a reduced measured rate after slowing the publisher"
         loa_slow = _subsystem(msg, "loa")
-        assert loa_slow.measured_publication_rate_hz < fast_rate, (
-            f"slow rate {loa_slow.measured_publication_rate_hz} should be < fast rate {fast_rate}"
-        )
-        assert loa_slow.measured_publication_rate_hz == pytest.approx(0.5, abs=0.4), (
-            f"expected loa rate ~0.5 Hz after slowing publisher, got {loa_slow.measured_publication_rate_hz}"
-        )
+        assert (
+            loa_slow.measured_publication_rate_hz < fast_rate
+        ), f"slow rate {loa_slow.measured_publication_rate_hz} should be < fast rate {fast_rate}"
+        assert loa_slow.measured_publication_rate_hz == pytest.approx(
+            0.5, abs=0.4
+        ), f"expected loa rate ~0.5 Hz after slowing publisher, got {loa_slow.measured_publication_rate_hz}"
     finally:
+        session.close()
+
+
+@pytest.mark.e2e
+def test_source_health_checks_field_published(
+    connector_process_factory, temp_dir: Path, zenoh_endpoints
+):
+    """Published SourceHealth carries structured per-check results.
+
+    Verifies:
+      - On NOMINAL, source-level detail is empty and checks[] has the
+        publication_rate entry at NOMINAL.
+      - After flipping the loa rate band so the observed rate is too slow,
+        the matching publication_rate CheckResult goes DEGRADED with a
+        non-empty per-check detail string.
+    """
+    initial_config = _make_health_config()
+    config_path = temp_dir / "health.json"
+    config_path.write_text(json.dumps(initial_config))
+
+    platform_config_path = temp_dir / "platform.json"
+    platform_config_path.write_text(
+        json.dumps(
+            {
+                "vessel_name": "Test Vessel",
+                "length_over_all_m": 25.0,
+                "breadth_over_all_m": 8.0,
+            }
+        )
+    )
+
+    test_conf = create_zenoh_config(
+        mode="peer",
+        connect=None,
+        listen=[zenoh_endpoints["listen"]],
+    )
+    session = zenoh.open(test_conf)
+
+    try:
+        collector = _HealthCollector()
+        sub = session.declare_subscriber(HEALTH_KEY, collector)
+
+        platform = connector_process_factory(
+            "platform",
+            "platform-geometry",
+            [
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                PLATFORM_SOURCE_ID,
+                "--config",
+                str(platform_config_path),
+                "--interval",
+                "1",
+                "--connect",
+                zenoh_endpoints["connect"],
+            ],
+        )
+        platform.start()
+
+        health = connector_process_factory(
+            "entity_health",
+            "entity_health2keelson",
+            [
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                HEALTH_SOURCE_ID,
+                "--config",
+                str(config_path),
+                "--connect",
+                zenoh_endpoints["connect"],
+            ],
+        )
+        health.start()
+
+        # --- NOMINAL: structured checks[] with publication_rate at NOMINAL ---
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_NOMINAL,
+            timeout=8.0,
+        )
+        assert msg is not None, "no NOMINAL EntityHealth received"
+        loa = _subsystem(msg, "loa")
+        rate_check = next((c for c in loa.checks if c.name == "publication_rate"), None)
+        assert (
+            rate_check is not None
+        ), f"no publication_rate check in {list(loa.checks)}"
+        assert rate_check.level == HEALTH_NOMINAL
+        assert rate_check.detail == ""
+        # activity check is also part of the structured output now
+        activity_check = next((c for c in loa.checks if c.name == "activity"), None)
+        assert activity_check is not None
+        assert activity_check.level == HEALTH_NOMINAL
+
+        # --- Flip the loa rate band so the observed rate goes DEGRADED ---
+        _set_config(
+            session,
+            _make_health_config(
+                loa_bands=[
+                    {"level": "NOMINAL", "min": 5.0, "max": 15.0},
+                    {"level": "DEGRADED", "min": 0.2, "max": 20.0},
+                ],
+            ),
+        )
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_DEGRADED,
+            timeout=8.0,
+        )
+        sub.undeclare()
+        assert (
+            msg is not None
+        ), "no DEGRADED EntityHealth received after flipping rate band"
+        loa = _subsystem(msg, "loa")
+        rate_check = next((c for c in loa.checks if c.name == "publication_rate"), None)
+        assert rate_check is not None
+        assert rate_check.level == HEALTH_DEGRADED
+        assert "DEGRADED" in rate_check.detail
+        assert "rate" in rate_check.detail
+    finally:
+        session.close()
+
+
+# --- gnss + gnss_quality content-rule e2e -------------------------------
+
+GNSS_SUBJECT_KEY = "test-realm/@v0/test-vessel/pubsub/location_fix/*"
+QUAL_SUBJECT_KEY = "test-realm/@v0/test-vessel/pubsub/location_fix_quality/*"
+GNSS_PUB_SOURCE = "gnss-mock"
+GNSS_FIX_KEY = construct_pubsub_key(REALM, ENTITY_ID, "location_fix", GNSS_PUB_SOURCE)
+GNSS_QUAL_KEY = construct_pubsub_key(
+    REALM, ENTITY_ID, "location_fix_quality", GNSS_PUB_SOURCE
+)
+
+
+def _gnss_health_config() -> dict:
+    """Two expectations mirroring example-config.json's gnss + gnss_quality.
+
+    `require_liveliness=False` so the test publisher (a thread, not a real
+    connector) doesn't need to declare liveliness tokens. Rate bands are
+    relaxed (1-50 Hz NOMINAL) so the publisher's ~10 Hz output keeps
+    publication_rate at NOMINAL throughout — the test focuses on content
+    rules and structured checks[].
+    """
+    rate_band = [{"level": "NOMINAL", "min": 1.0, "max": 50.0}]
+    return {
+        "publish_rate_hz": 5.0,
+        "expectations": [
+            {
+                "name": "gnss",
+                "key_expr": GNSS_SUBJECT_KEY,
+                "inactive_after_s": 5.0,
+                "window_s": 2.0,
+                "publication_rate_hz": rate_band,
+                "publication_rate_default_level": "CRITICAL",
+                "require_liveliness": False,
+                "content_rules": [
+                    {
+                        "field": "latitude",
+                        "bands": [{"level": "NOMINAL", "min": -90, "max": 90}],
+                        "default_level": "CRITICAL",
+                    },
+                    {
+                        "field": "longitude",
+                        "bands": [{"level": "NOMINAL", "min": -180, "max": 180}],
+                        "default_level": "CRITICAL",
+                    },
+                ],
+            },
+            {
+                "name": "gnss_quality",
+                "key_expr": QUAL_SUBJECT_KEY,
+                "inactive_after_s": 5.0,
+                "window_s": 2.0,
+                "publication_rate_hz": rate_band,
+                "publication_rate_default_level": "CRITICAL",
+                "require_liveliness": False,
+                "content_rules": [
+                    {
+                        "field": "fix_type",
+                        "bands": [
+                            {
+                                "level": "NOMINAL",
+                                "equals": ["FIX_3D_RTK", "FIX_3D"],
+                            },
+                            {
+                                "level": "DEGRADED",
+                                "equals": ["FIX_3D_DGPS", "FIX_2D", "GPS_DR"],
+                            },
+                            {
+                                "level": "CRITICAL",
+                                "equals": [
+                                    "INVALID",
+                                    "FIX_NO",
+                                    "UNKNOWN",
+                                    "TIME_ONLY",
+                                    "DR_ONLY",
+                                ],
+                            },
+                        ],
+                        "default_level": "CRITICAL",
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.e2e
+def test_gnss_content_rules_with_structured_checks(
+    connector_process_factory, temp_dir: Path, zenoh_endpoints
+):
+    """Walk gnss + gnss_quality through NOMINAL → DEGRADED (fix downgrades
+    RTK→DGPS) → CRITICAL (latitude out of range), verifying that the
+    structured `checks[]` field carries one entry per check (rate +
+    each content rule) and that levels/details flip independently.
+    """
+    config_path = temp_dir / "health.json"
+    config_path.write_text(json.dumps(_gnss_health_config()))
+
+    test_conf = create_zenoh_config(
+        mode="peer",
+        connect=None,
+        listen=[zenoh_endpoints["listen"]],
+    )
+    session = zenoh.open(test_conf)
+
+    fix_pub = session.declare_publisher(GNSS_FIX_KEY)
+    qual_pub = session.declare_publisher(GNSS_QUAL_KEY)
+
+    state_lock = threading.Lock()
+    state = {
+        "lat": 45.0,
+        "lon": 10.0,
+        "fix": LocationFixQuality.FIX_3D_RTK,
+        "stop": False,
+    }
+
+    def publish_loop() -> None:
+        while True:
+            with state_lock:
+                if state["stop"]:
+                    return
+                lat, lon, fix = state["lat"], state["lon"], state["fix"]
+            fix_msg = LocationFix()
+            fix_msg.latitude = lat
+            fix_msg.longitude = lon
+            fix_pub.put(enclose(fix_msg.SerializeToString()))
+            qual_msg = LocationFixQuality()
+            qual_msg.fix_type = fix
+            qual_pub.put(enclose(qual_msg.SerializeToString()))
+            time.sleep(0.1)  # ~10 Hz
+
+    pub_thread = threading.Thread(target=publish_loop, daemon=True)
+    pub_thread.start()
+
+    try:
+        collector = _HealthCollector()
+        sub = session.declare_subscriber(HEALTH_KEY, collector)
+
+        health = connector_process_factory(
+            "entity_health",
+            "entity_health2keelson",
+            [
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                HEALTH_SOURCE_ID,
+                "--config",
+                str(config_path),
+                "--connect",
+                zenoh_endpoints["connect"],
+            ],
+        )
+        health.start()
+
+        # === Phase 1: All NOMINAL ===
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "gnss") is not None
+            and _subsystem(m, "gnss").level == HEALTH_NOMINAL
+            and _subsystem(m, "gnss_quality") is not None
+            and _subsystem(m, "gnss_quality").level == HEALTH_NOMINAL,
+            timeout=10.0,
+        )
+        assert msg is not None, "no all-NOMINAL EntityHealth received"
+        assert msg.level == HEALTH_NOMINAL
+        gnss = _subsystem(msg, "gnss")
+        qual = _subsystem(msg, "gnss_quality")
+        assert {c.name for c in gnss.checks} == {
+            "activity",
+            "publication_rate",
+            "latitude",
+            "longitude",
+        }
+        assert all(c.level == HEALTH_NOMINAL for c in gnss.checks)
+        assert all(c.detail == "" for c in gnss.checks)
+        assert {c.name for c in qual.checks} == {
+            "activity",
+            "publication_rate",
+            "fix_type",
+        }
+        assert all(c.level == HEALTH_NOMINAL for c in qual.checks)
+        assert all(c.detail == "" for c in qual.checks)
+
+        # === Phase 2: fix downgrades RTK → DGPS → gnss_quality DEGRADED ===
+        with state_lock:
+            state["fix"] = LocationFixQuality.FIX_3D_DGPS
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "gnss_quality") is not None
+            and _subsystem(m, "gnss_quality").level == HEALTH_DEGRADED,
+            timeout=10.0,
+        )
+        gnss = _subsystem(msg, "gnss")
+        qual = _subsystem(msg, "gnss_quality")
+        assert (
+            gnss.level == HEALTH_NOMINAL
+        ), "gnss should be unaffected by fix_type change"
+        assert qual.level == HEALTH_DEGRADED
+        fix_check = next(c for c in qual.checks if c.name == "fix_type")
+        rate_check_qual = next(c for c in qual.checks if c.name == "publication_rate")
+        assert fix_check.level == HEALTH_DEGRADED
+        assert "FIX_3D_DGPS" in fix_check.detail
+        assert "DEGRADED" in fix_check.detail
+        assert (
+            rate_check_qual.level == HEALTH_NOMINAL
+        ), "rate check on gnss_quality should still be NOMINAL"
+        assert rate_check_qual.detail == ""
+        # Entity tracks the worst across sources
+        assert msg.level == HEALTH_DEGRADED
+
+        # === Phase 3: latitude out of range → gnss CRITICAL, quality stays DEGRADED ===
+        with state_lock:
+            state["lat"] = 200.0  # outside [-90, 90]
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "gnss") is not None
+            and _subsystem(m, "gnss").level == HEALTH_CRITICAL
+            and _subsystem(m, "gnss_quality") is not None
+            and _subsystem(m, "gnss_quality").level == HEALTH_DEGRADED,
+            timeout=10.0,
+        )
+        sub.undeclare()
+        gnss = _subsystem(msg, "gnss")
+        qual = _subsystem(msg, "gnss_quality")
+        assert gnss.level == HEALTH_CRITICAL
+        lat_check = next(c for c in gnss.checks if c.name == "latitude")
+        lon_check = next(c for c in gnss.checks if c.name == "longitude")
+        rate_check_gnss = next(c for c in gnss.checks if c.name == "publication_rate")
+        assert lat_check.level == HEALTH_CRITICAL
+        assert "latitude=200" in lat_check.detail
+        assert "outside" in lat_check.detail
+        # longitude and rate stay clean — proves per-check independence
+        assert lon_check.level == HEALTH_NOMINAL
+        assert lon_check.detail == ""
+        assert rate_check_gnss.level == HEALTH_NOMINAL
+        assert rate_check_gnss.detail == ""
+        # gnss_quality still DEGRADED (fix_type unchanged from phase 2)
+        assert qual.level == HEALTH_DEGRADED
+        # Entity reflects worst-of (CRITICAL > DEGRADED)
+        assert msg.level == HEALTH_CRITICAL
+    finally:
+        with state_lock:
+            state["stop"] = True
+        pub_thread.join(timeout=2.0)
+        fix_pub.undeclare()
+        qual_pub.undeclare()
         session.close()

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -308,3 +308,131 @@ def test_entity_health_full_lifecycle(
         assert "liveliness" in boa.detail
     finally:
         session.close()
+
+
+@pytest.mark.e2e
+def test_measured_publication_rate_tracks_publisher(
+    connector_process_factory, temp_dir: Path, zenoh_endpoints
+):
+    """SourceHealth.measured_publication_rate_hz must reflect the publisher's
+    actual rate, and must change when the publisher's rate changes.
+
+    Phase A: publisher at 1s interval (~1 Hz) → measured rate ≈ 1.0
+    Phase B: replace with publisher at 2s interval (~0.5 Hz) → measured rate drops
+    """
+    # Wide rate band so both 1.0 Hz and 0.5 Hz stay NOMINAL — the test is
+    # about the *measured* rate, not the level. window_s small so the
+    # measurement reacts to the rate change quickly.
+    wide_band = [{"level": "NOMINAL", "min": 0.1, "max": 5.0}]
+    config = _make_health_config(
+        loa_bands=wide_band,
+        boa_bands=wide_band,
+        inactive_after_s=5.0,
+        window_s=3.0,
+    )
+    config_path = temp_dir / "health.json"
+    config_path.write_text(json.dumps(config))
+
+    platform_config_path = temp_dir / "platform.json"
+    platform_config_path.write_text(
+        json.dumps(
+            {
+                "vessel_name": "Test Vessel",
+                "length_over_all_m": 25.0,
+                "breadth_over_all_m": 8.0,
+            }
+        )
+    )
+
+    test_conf = create_zenoh_config(
+        mode="peer",
+        connect=None,
+        listen=[zenoh_endpoints["listen"]],
+    )
+    session = zenoh.open(test_conf)
+
+    def _platform(interval_s: int):
+        return connector_process_factory(
+            "platform",
+            "platform-geometry",
+            [
+                "--realm", REALM,
+                "--entity-id", ENTITY_ID,
+                "--source-id", PLATFORM_SOURCE_ID,
+                "--config", str(platform_config_path),
+                "--interval", str(interval_s),
+                "--connect", zenoh_endpoints["connect"],
+            ],
+        )
+
+    try:
+        collector = _HealthCollector()
+        sub = session.declare_subscriber(HEALTH_KEY, collector)
+
+        # --- Phase A: 1 Hz publisher ---
+        platform_fast = _platform(1)
+        platform_fast.start()
+
+        health = connector_process_factory(
+            "entity_health",
+            "entity_health2keelson",
+            [
+                "--realm", REALM,
+                "--entity-id", ENTITY_ID,
+                "--source-id", HEALTH_SOURCE_ID,
+                "--config", str(config_path),
+                "--connect", zenoh_endpoints["connect"],
+            ],
+        )
+        health.start()
+
+        # Wait for a NOMINAL message where the measured rate has stabilised
+        # near 1 Hz (window_s=3 → ~3 samples → 1.0 Hz).
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_NOMINAL
+            and _subsystem(m, "loa").measured_publication_rate_hz >= 0.8,
+            timeout=10.0,
+        )
+        assert msg is not None, "no EntityHealth received in phase A"
+        loa_fast = _subsystem(msg, "loa")
+        boa_fast = _subsystem(msg, "boa")
+        assert loa_fast.measured_publication_rate_hz > 0.0, (
+            "measured_publication_rate_hz should be non-zero when samples are flowing"
+        )
+        assert loa_fast.measured_publication_rate_hz == pytest.approx(1.0, abs=0.5), (
+            f"expected loa rate ~1.0 Hz, got {loa_fast.measured_publication_rate_hz}"
+        )
+        assert boa_fast.measured_publication_rate_hz == pytest.approx(1.0, abs=0.5), (
+            f"expected boa rate ~1.0 Hz, got {boa_fast.measured_publication_rate_hz}"
+        )
+        fast_rate = loa_fast.measured_publication_rate_hz
+
+        # --- Phase B: swap to 0.5 Hz publisher ---
+        platform_fast.stop()
+        platform_slow = _platform(2)
+        platform_slow.start()
+
+        # The window must drain the 1 Hz samples (3s window) and refill with
+        # 0.5 Hz samples, so we allow generous time. We accept the new rate
+        # as soon as it has clearly dropped and is positive.
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_NOMINAL
+            and 0.0 < _subsystem(m, "loa").measured_publication_rate_hz
+            and _subsystem(m, "loa").measured_publication_rate_hz < fast_rate * 0.8,
+            timeout=15.0,
+        )
+        sub.undeclare()
+        assert msg is not None, (
+            "expected a NOMINAL message with a reduced measured rate after slowing the publisher"
+        )
+        loa_slow = _subsystem(msg, "loa")
+        assert loa_slow.measured_publication_rate_hz < fast_rate, (
+            f"slow rate {loa_slow.measured_publication_rate_hz} should be < fast rate {fast_rate}"
+        )
+        assert loa_slow.measured_publication_rate_hz == pytest.approx(0.5, abs=0.4), (
+            f"expected loa rate ~0.5 Hz after slowing publisher, got {loa_slow.measured_publication_rate_hz}"
+        )
+    finally:
+        session.close()

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -110,7 +110,7 @@ class _HealthCollector:
 
 
 def _subsystem(msg: EntityHealth, name: str):
-    for s in msg.sources:
+    for s in msg.subjects:
         if s.name == name:
             return s
     return None
@@ -221,7 +221,7 @@ def test_entity_health_full_lifecycle(
         assert loa.level == HEALTH_NOMINAL
         assert boa.level == HEALTH_NOMINAL
         assert msg.rate_hz == pytest.approx(5.0)
-        assert {s.name for s in msg.sources} == {"loa", "boa"}
+        assert {s.name for s in msg.subjects} == {"loa", "boa"}
         # checks[] should carry the per-check NOMINAL results
         assert {c.name for c in loa.checks} == {"activity", "publication_rate"}
         assert all(c.level == HEALTH_NOMINAL for c in loa.checks)
@@ -318,7 +318,7 @@ def test_entity_health_full_lifecycle(
 def test_measured_publication_rate_tracks_publisher(
     connector_process_factory, temp_dir: Path, zenoh_endpoints
 ):
-    """SourceHealth.measured_publication_rate_hz must reflect the publisher's
+    """SubjectHealth.measured_publication_rate_hz must reflect the publisher's
     actual rate, and must change when the publisher's rate changes.
 
     Phase A: publisher at 1s interval (~1 Hz) → measured rate ≈ 1.0
@@ -457,7 +457,7 @@ def test_measured_publication_rate_tracks_publisher(
 def test_source_health_checks_field_published(
     connector_process_factory, temp_dir: Path, zenoh_endpoints
 ):
-    """Published SourceHealth carries structured per-check results.
+    """Published SubjectHealth carries structured per-check results.
 
     Verifies:
       - On NOMINAL, source-level detail is empty and checks[] has the

--- a/connectors/entity_health/tests/test_entity_health_e2e.py
+++ b/connectors/entity_health/tests/test_entity_health_e2e.py
@@ -1,0 +1,310 @@
+"""End-to-end tests for the entity_health connector.
+
+These tests run the connector against a real Zenoh peer mesh, with
+`platform-geometry` acting as a publishing data source. The test
+process opens its own Zenoh session to:
+
+  - subscribe to the connector's `entity_health` output and decode
+    the protobuf payload directly,
+  - drive the connector through `set_config` RPC calls.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import zenoh
+
+import keelson
+from keelson import construct_pubsub_key, construct_rpc_key
+from keelson.payloads.EntityHealth_pb2 import (
+    EntityHealth,
+    HEALTH_CRITICAL,
+    HEALTH_DEGRADED,
+    HEALTH_NOMINAL,
+    HEALTH_UNKNOWN,
+)
+from keelson.scaffolding import create_zenoh_config
+
+
+REALM = "test-realm"
+ENTITY_ID = "test-vessel"
+HEALTH_SOURCE_ID = "health"
+PLATFORM_SOURCE_ID = "geometry"
+
+HEALTH_KEY = construct_pubsub_key(REALM, ENTITY_ID, "entity_health", HEALTH_SOURCE_ID)
+SET_CONFIG_KEY = construct_rpc_key(REALM, ENTITY_ID, "set_config", HEALTH_SOURCE_ID)
+LOA_KEY = "test-realm/@v0/test-vessel/pubsub/length_over_all_m/*"
+BOA_KEY = "test-realm/@v0/test-vessel/pubsub/breadth_over_all_m/*"
+
+
+# A "calm" band wide enough to keep the platform's ~1 Hz publishing in NOMINAL.
+_CALM_BANDS = [
+    {"level": "NOMINAL", "min": 0.5, "max": 5.0},
+    {"level": "DEGRADED", "min": 0.1, "max": 10.0},
+]
+
+
+def _make_health_config(
+    loa_bands: list[dict] = _CALM_BANDS,
+    boa_bands: list[dict] = _CALM_BANDS,
+    inactive_after_s: float = 2.0,
+    window_s: float = 2.0,
+) -> dict:
+    """Two-subsystem config so we can verify worst-wins aggregation."""
+    return {
+        "publish_rate_hz": 5.0,
+        "expectations": [
+            {
+                "name": "loa",
+                "key_expr": LOA_KEY,
+                "inactive_after_s": inactive_after_s,
+                "window_s": window_s,
+                "publication_rate_hz": loa_bands,
+                "publication_rate_default_level": "CRITICAL",
+                "require_liveliness": True,
+            },
+            {
+                "name": "boa",
+                "key_expr": BOA_KEY,
+                "inactive_after_s": inactive_after_s,
+                "window_s": window_s,
+                "publication_rate_hz": boa_bands,
+                "publication_rate_default_level": "CRITICAL",
+                "require_liveliness": True,
+            },
+        ],
+    }
+
+
+class _HealthCollector:
+    """Subscribes to entity_health and decodes EntityHealth payloads."""
+
+    def __init__(self) -> None:
+        self.messages: list[EntityHealth] = []
+
+    def __call__(self, sample: zenoh.Sample) -> None:
+        try:
+            _r, _e, payload = keelson.uncover(sample.payload.to_bytes())
+            msg = EntityHealth()
+            msg.ParseFromString(payload)
+            self.messages.append(msg)
+        except Exception:
+            pass
+
+    def clear(self) -> None:
+        self.messages.clear()
+
+    def wait_for(self, predicate, timeout: float = 6.0) -> EntityHealth | None:
+        """Wait until the most recent message satisfies `predicate`."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.messages and predicate(self.messages[-1]):
+                return self.messages[-1]
+            time.sleep(0.1)
+        return self.messages[-1] if self.messages else None
+
+
+def _subsystem(msg: EntityHealth, name: str):
+    for s in msg.subsystems:
+        if s.name == name:
+            return s
+    return None
+
+
+def _set_config(session: zenoh.Session, new_config: dict) -> None:
+    """Send a set_config RPC and wait briefly for the reply."""
+    replies: list = []
+    session.get(
+        SET_CONFIG_KEY,
+        lambda r: replies.append(r),
+        payload=json.dumps(new_config).encode(),
+    )
+    # Give the queryable time to respond
+    time.sleep(0.5)
+
+
+@pytest.mark.e2e
+def test_entity_health_full_lifecycle(
+    connector_process_factory, temp_dir: Path, zenoh_endpoints
+):
+    """Walk a two-subsystem config through NOMINAL → DEGRADED → CRITICAL → UNKNOWN.
+
+    Only the `loa` subsystem is degraded across phases; `boa` stays NOMINAL.
+    The overall `EntityHealth.level` should track the *worst* subsystem.
+    """
+    initial_config = _make_health_config()
+    config_path = temp_dir / "health.json"
+    config_path.write_text(json.dumps(initial_config))
+
+    platform_config_path = temp_dir / "platform.json"
+    platform_config_path.write_text(
+        json.dumps(
+            {
+                "vessel_name": "Test Vessel",
+                "length_over_all_m": 25.0,
+                "breadth_over_all_m": 8.0,
+            }
+        )
+    )
+
+    # --- Test session listens on the shared endpoint so connectors can connect ---
+    test_conf = create_zenoh_config(
+        mode="peer",
+        connect=None,
+        listen=[zenoh_endpoints["listen"]],
+    )
+    session = zenoh.open(test_conf)
+
+    try:
+        collector = _HealthCollector()
+        sub = session.declare_subscriber(HEALTH_KEY, collector)
+
+        # --- Start the data source (declares liveliness + publishes both fields ~1 Hz) ---
+        platform = connector_process_factory(
+            "platform",
+            "platform-geometry",
+            [
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                PLATFORM_SOURCE_ID,
+                "--config",
+                str(platform_config_path),
+                "--interval",
+                "1",
+                "--connect",
+                zenoh_endpoints["connect"],
+            ],
+        )
+        platform.start()
+
+        # --- Start the connector under test ---
+        health = connector_process_factory(
+            "entity_health",
+            "entity_health2keelson",
+            [
+                "--realm",
+                REALM,
+                "--entity-id",
+                ENTITY_ID,
+                "--source-id",
+                HEALTH_SOURCE_ID,
+                "--config",
+                str(config_path),
+                "--connect",
+                zenoh_endpoints["connect"],
+            ],
+        )
+        health.start()
+
+        # === Phase 1: both subsystems NOMINAL → entity NOMINAL ===
+        time.sleep(4.0)
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "boa") is not None
+            and _subsystem(m, "loa").level == HEALTH_NOMINAL
+            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+        )
+        assert msg is not None, "no EntityHealth received"
+        assert msg.level == HEALTH_NOMINAL
+        loa = _subsystem(msg, "loa")
+        boa = _subsystem(msg, "boa")
+        assert loa.name == "loa"
+        assert boa.name == "boa"
+        assert loa.level == HEALTH_NOMINAL
+        assert boa.level == HEALTH_NOMINAL
+        assert loa.detail == "ok", f"loa detail: {loa.detail!r}"
+        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
+        assert msg.rate_hz == pytest.approx(5.0)
+        assert {s.name for s in msg.subsystems} == {"loa", "boa"}
+
+        # === Phase 2: degrade only loa → entity DEGRADED, boa still NOMINAL ===
+        _set_config(
+            session,
+            _make_health_config(
+                loa_bands=[
+                    {"level": "NOMINAL", "min": 5.0, "max": 15.0},
+                    {"level": "DEGRADED", "min": 0.2, "max": 20.0},
+                ],
+            ),
+        )
+        time.sleep(3.0)
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_DEGRADED
+            and _subsystem(m, "boa") is not None
+            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+        )
+        loa = _subsystem(msg, "loa")
+        boa = _subsystem(msg, "boa")
+        assert loa.level == HEALTH_DEGRADED, loa
+        assert boa.level == HEALTH_NOMINAL, boa
+        assert (
+            "DEGRADED" in loa.detail
+        ), f"expected DEGRADED-band detail on loa, got {loa.detail!r}"
+        assert "rate" in loa.detail, f"loa detail: {loa.detail!r}"
+        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
+        assert (
+            msg.level == HEALTH_DEGRADED
+        ), f"entity should reflect worst subsystem (DEGRADED), got {msg.level}"
+
+        # === Phase 3: critical only loa → entity CRITICAL, boa still NOMINAL ===
+        _set_config(
+            session,
+            _make_health_config(
+                loa_bands=[
+                    {"level": "NOMINAL", "min": 50.0, "max": 100.0},
+                    {"level": "DEGRADED", "min": 30.0, "max": 110.0},
+                ],
+            ),
+        )
+        time.sleep(3.0)
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_CRITICAL
+            and _subsystem(m, "boa") is not None
+            and _subsystem(m, "boa").level == HEALTH_NOMINAL
+        )
+        loa = _subsystem(msg, "loa")
+        boa = _subsystem(msg, "boa")
+        assert loa.level == HEALTH_CRITICAL, loa
+        assert boa.level == HEALTH_NOMINAL, boa
+        assert (
+            "outside all rate bands" in loa.detail
+        ), f"expected fall-through detail on loa, got {loa.detail!r}"
+        assert boa.detail == "ok", f"boa detail: {boa.detail!r}"
+        assert (
+            msg.level == HEALTH_CRITICAL
+        ), f"entity should reflect worst subsystem (CRITICAL), got {msg.level}"
+
+        # === Phase 4: stop platform → both subsystems lose liveliness → UNKNOWN ===
+        collector.clear()
+        platform.stop()
+        msg = collector.wait_for(
+            lambda m: _subsystem(m, "loa") is not None
+            and _subsystem(m, "loa").level == HEALTH_UNKNOWN
+            and _subsystem(m, "boa") is not None
+            and _subsystem(m, "boa").level == HEALTH_UNKNOWN,
+            timeout=8.0,
+        )
+        loa = _subsystem(msg, "loa")
+        boa = _subsystem(msg, "boa")
+        sub.undeclare()
+        health.stop()
+        assert (
+            loa.level == HEALTH_UNKNOWN
+        ), f"expected loa UNKNOWN, got {loa.level}: {loa.detail}"
+        assert (
+            boa.level == HEALTH_UNKNOWN
+        ), f"expected boa UNKNOWN, got {boa.level}: {boa.detail}"
+        assert (
+            msg.level == HEALTH_UNKNOWN
+        ), f"entity should be UNKNOWN when all subsystems are UNKNOWN, got {msg.level}"
+        assert "liveliness" in loa.detail
+        assert "liveliness" in boa.detail
+    finally:
+        session.close()

--- a/connectors/entity_health/tests/test_evaluator_unit.py
+++ b/connectors/entity_health/tests/test_evaluator_unit.py
@@ -8,7 +8,7 @@ from entity_health.evaluator import (
     ContentRule,
     Evaluator,
     Expectation,
-    SourceState,
+    SubjectState,
     evaluate_all,
     parse_level,
     HEALTH_CRITICAL,
@@ -343,15 +343,15 @@ def test_measured_rate_uses_sliding_window():
 # --- proto schema -------------------------------------------------------
 
 
-def test_protobuf_source_health_has_checks_field():
-    """SourceHealth proto must expose a repeated CheckResult `checks` field."""
+def test_protobuf_subject_health_has_checks_field():
+    """SubjectHealth proto must expose a repeated CheckResult `checks` field."""
     from keelson.payloads.EntityHealth_pb2 import (
         CheckResult as ProtoCheckResult,
-        SourceHealth,
+        SubjectHealth,
         HEALTH_NOMINAL as PROTO_NOMINAL,
     )
 
-    sh = SourceHealth()
+    sh = SubjectHealth()
     cr = sh.checks.add()
     cr.name = "publication_rate"
     cr.level = PROTO_NOMINAL
@@ -479,9 +479,9 @@ def test_checks_carry_per_check_levels_and_details_when_mixed():
     assert rate is not None and rate.level == HEALTH_NOMINAL
 
 
-def test_source_state_has_empty_checks_by_default():
-    """SourceState should expose a `checks` list, defaulting to empty."""
-    state = SourceState(name="x", level=HEALTH_NOMINAL)
+def test_subject_state_has_empty_checks_by_default():
+    """SubjectState should expose a `checks` list, defaulting to empty."""
+    state = SubjectState(name="x", level=HEALTH_NOMINAL)
     assert state.checks == []
 
 

--- a/connectors/entity_health/tests/test_evaluator_unit.py
+++ b/connectors/entity_health/tests/test_evaluator_unit.py
@@ -2,14 +2,17 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from entity_health.evaluator import (
     Band,
     CheckResult,
     ContentRule,
     Evaluator,
     Expectation,
+    SourceState,
     SubjectState,
-    evaluate_all,
+    evaluate_grouped,
     parse_level,
     HEALTH_CRITICAL,
     HEALTH_DEGRADED,
@@ -31,7 +34,6 @@ def _publication_rate_hz_for(expected: float, tol_pct: float = 20.0) -> list[Ban
 def _make(**kwargs) -> Evaluator:
     defaults = dict(
         name="x",
-        key_expr="k/**",
         inactive_after_s=2.0,
         window_s=2.0,
         publication_rate_hz=_publication_rate_hz_for(10.0, 20.0),
@@ -154,21 +156,50 @@ def test_content_rule_in_range_is_nominal():
     assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_NOMINAL
 
 
-def test_evaluate_all_aggregates_worst():
+def test_evaluate_grouped_aggregates_worst_within_a_source():
+    """Two subjects on the same source: source level is the worst of them."""
     good = _make(name="good")
     bad = _make(name="bad", inactive_after_s=1.0)
     for i in range(20):
         good.record(now=1000.0 + i * 0.1)
     bad.record(now=1000.0)
-    overall, states = evaluate_all([good, bad], now=1005.0)
+    overall, sources = evaluate_grouped(
+        {("dev1", "good"): good, ("dev1", "bad"): bad}, now=1005.0
+    )
     assert overall == HEALTH_INACTIVE
-    assert {s.name for s in states} == {"good", "bad"}
+    assert len(sources) == 1
+    src = sources[0]
+    assert src.name == "dev1"
+    assert src.level == HEALTH_INACTIVE
+    assert {s.name for s in src.subjects} == {"good", "bad"}
 
 
-def test_evaluate_all_empty_is_unknown():
-    overall, states = evaluate_all([], now=100.0)
+def test_evaluate_grouped_one_subject_per_source():
+    """Two sources, one subject each → two SourceStates, entity worst of both."""
+    healthy = _make(inactive_after_s=5.0)
+    inactive = _make(inactive_after_s=1.0)
+    for i in range(20):
+        healthy.record(now=1000.0 + i * 0.1)
+    inactive.record(now=1000.0)
+    overall, sources = evaluate_grouped(
+        {("dev_a", "x"): healthy, ("dev_b", "x"): inactive}, now=1002.0
+    )
+    assert overall == HEALTH_INACTIVE
+    by_name = {s.name: s for s in sources}
+    assert set(by_name) == {"dev_a", "dev_b"}
+    assert by_name["dev_a"].level == HEALTH_NOMINAL
+    assert by_name["dev_b"].level == HEALTH_INACTIVE
+
+
+def test_evaluate_grouped_empty_is_unknown():
+    overall, sources = evaluate_grouped({}, now=100.0)
     assert overall == HEALTH_UNKNOWN
-    assert states == []
+    assert sources == []
+
+
+def test_source_state_defaults():
+    s = SourceState(name="dev", level=HEALTH_NOMINAL)
+    assert s.subjects == []
 
 
 # --- Tiered band tests ----------------------------------------------------
@@ -179,31 +210,23 @@ def _band_eval(value, **rule_kwargs):
     return rule.evaluate(SimpleNamespace(value=value))[0]
 
 
-def test_band_nominal_match():
-    bands = [
-        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
-        Band(level=HEALTH_DEGRADED, min=11, max=15),
-        Band(level=HEALTH_CRITICAL, min=10, max=16),
-    ]
-    assert _band_eval(13.0, bands=bands) == HEALTH_NOMINAL
+_TIERED_BANDS = [
+    Band(level=HEALTH_NOMINAL, min=12, max=14.5),
+    Band(level=HEALTH_DEGRADED, min=11, max=15),
+    Band(level=HEALTH_CRITICAL, min=10, max=16),
+]
 
 
-def test_band_degraded_match():
-    bands = [
-        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
-        Band(level=HEALTH_DEGRADED, min=11, max=15),
-        Band(level=HEALTH_CRITICAL, min=10, max=16),
-    ]
-    assert _band_eval(11.5, bands=bands) == HEALTH_DEGRADED
-
-
-def test_band_critical_match():
-    bands = [
-        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
-        Band(level=HEALTH_DEGRADED, min=11, max=15),
-        Band(level=HEALTH_CRITICAL, min=10, max=16),
-    ]
-    assert _band_eval(15.5, bands=bands) == HEALTH_CRITICAL
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (13.0, HEALTH_NOMINAL),
+        (11.5, HEALTH_DEGRADED),
+        (15.5, HEALTH_CRITICAL),
+    ],
+)
+def test_band_tiered_match(value, expected):
+    assert _band_eval(value, bands=_TIERED_BANDS) == expected
 
 
 def test_band_no_match_uses_default_level():
@@ -220,7 +243,6 @@ def test_evaluator_combines_rate_and_tiered_content_worst_wins():
     ]
     exp = Expectation(
         name="batt",
-        key_expr="k/**",
         inactive_after_s=5.0,
         window_s=2.0,
         publication_rate_hz=_publication_rate_hz_for(10.0, 20.0),

--- a/connectors/entity_health/tests/test_evaluator_unit.py
+++ b/connectors/entity_health/tests/test_evaluator_unit.py
@@ -1,0 +1,285 @@
+"""Unit tests for the pure evaluator logic (no Zenoh)."""
+
+from types import SimpleNamespace
+
+from entity_health.evaluator import (
+    Band,
+    ContentRule,
+    Evaluator,
+    Expectation,
+    evaluate_all,
+    parse_level,
+    HEALTH_CRITICAL,
+    HEALTH_DEGRADED,
+    HEALTH_INACTIVE,
+    HEALTH_NOMINAL,
+    HEALTH_UNKNOWN,
+)
+
+
+def _publication_rate_hz_for(expected: float, tol_pct: float = 20.0) -> list[Band]:
+    """Nominal within ±tol, DEGRADED within ±2×tol, otherwise CRITICAL."""
+    tol = expected * (tol_pct / 100.0)
+    return [
+        Band(level=HEALTH_NOMINAL, min=expected - tol, max=expected + tol),
+        Band(level=HEALTH_DEGRADED, min=expected - 2 * tol, max=expected + 2 * tol),
+    ]
+
+
+def _make(**kwargs) -> Evaluator:
+    defaults = dict(
+        name="x",
+        key_expr="k/**",
+        inactive_after_s=2.0,
+        window_s=2.0,
+        publication_rate_hz=_publication_rate_hz_for(10.0, 20.0),
+        require_liveliness=False,
+    )
+    defaults.update(kwargs)
+    return Evaluator(Expectation(**defaults))
+
+
+def test_no_samples_without_liveliness_required_is_inactive():
+    ev = _make()
+    assert ev.evaluate(now=100.0).level == HEALTH_INACTIVE
+
+
+def test_no_liveliness_token_is_unknown():
+    ev = _make(require_liveliness=True)
+    assert ev.evaluate(now=100.0).level == HEALTH_UNKNOWN
+    assert "liveliness" in ev.evaluate(now=100.0).detail
+
+
+def test_liveliness_present_no_samples_is_inactive():
+    ev = _make(require_liveliness=True)
+    ev.set_alive("k/a")
+    state = ev.evaluate(now=100.0)
+    assert state.level == HEALTH_INACTIVE
+    assert "alive but no samples" in state.detail
+
+
+def test_liveliness_present_with_data_is_nominal():
+    ev = _make(require_liveliness=True)
+    ev.set_alive("k/a")
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)
+    assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_NOMINAL
+
+
+def test_liveliness_removed_goes_back_to_unknown():
+    ev = _make(require_liveliness=True)
+    ev.set_alive("k/a")
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)
+    assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_NOMINAL
+    ev.set_dead("k/a")
+    assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_UNKNOWN
+
+
+def test_liveliness_tracks_multiple_sources():
+    ev = _make(require_liveliness=True)
+    ev.set_alive("k/a")
+    ev.set_alive("k/b")
+    ev.set_dead("k/a")
+    assert ev.is_alive
+    ev.set_dead("k/b")
+    assert not ev.is_alive
+
+
+def test_rate_within_tolerance_is_nominal():
+    ev = _make()
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)  # 10 Hz
+    assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_NOMINAL
+
+
+def test_silence_beyond_inactive_after_is_inactive():
+    ev = _make(inactive_after_s=2.0)
+    ev.record(now=100.0)
+    state = ev.evaluate(now=105.0)
+    assert state.level == HEALTH_INACTIVE
+    assert "silent" in state.detail
+
+
+def test_rate_in_degraded_band():
+    ev = _make(publication_rate_hz=_publication_rate_hz_for(10.0, 20.0))
+    # 5 Hz — outside NOMINAL [8,12] but inside DEGRADED [6,14]... wait, recompute
+    # tol=2 → NOMINAL [8,12], DEGRADED [6,14]. Use 7 Hz to land in DEGRADED.
+    for i in range(14):
+        ev.record(now=1000.0 + i / 7.0)
+    level = ev.evaluate(now=1000.0 + 2.0).level
+    assert level == HEALTH_DEGRADED
+
+
+def test_rate_outside_all_bands_uses_default_level():
+    ev = _make(publication_rate_hz=_publication_rate_hz_for(10.0, 20.0))
+    # 2 Hz — outside both NOMINAL and DEGRADED bands → default CRITICAL
+    for i in range(4):
+        ev.record(now=1000.0 + i * 0.5)
+    level = ev.evaluate(now=1000.0 + 2.0).level
+    assert level == HEALTH_CRITICAL
+
+
+def _lat_rule() -> ContentRule:
+    return ContentRule(
+        field="latitude",
+        bands=[Band(level=HEALTH_NOMINAL, min=-90, max=90)],
+        default_level=HEALTH_CRITICAL,
+    )
+
+
+def test_content_rule_out_of_range_uses_default_level():
+    ev = _make(content_rules=[_lat_rule()])
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1, payload=SimpleNamespace(latitude=200.0))
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert state.level == HEALTH_CRITICAL
+    assert "latitude" in state.detail
+
+
+def test_content_rule_in_range_is_nominal():
+    ev = _make(content_rules=[_lat_rule()])
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1, payload=SimpleNamespace(latitude=45.0))
+    assert ev.evaluate(now=1000.0 + 2.0).level == HEALTH_NOMINAL
+
+
+def test_evaluate_all_aggregates_worst():
+    good = _make(name="good")
+    bad = _make(name="bad", inactive_after_s=1.0)
+    for i in range(20):
+        good.record(now=1000.0 + i * 0.1)
+    bad.record(now=1000.0)
+    overall, states = evaluate_all([good, bad], now=1005.0)
+    assert overall == HEALTH_INACTIVE
+    assert {s.name for s in states} == {"good", "bad"}
+
+
+def test_evaluate_all_empty_is_unknown():
+    overall, states = evaluate_all([], now=100.0)
+    assert overall == HEALTH_UNKNOWN
+    assert states == []
+
+
+# --- Tiered band tests ----------------------------------------------------
+
+
+def _band_eval(value, **rule_kwargs):
+    rule = ContentRule(field="value", **rule_kwargs)
+    return rule.evaluate(SimpleNamespace(value=value))[0]
+
+
+def test_band_nominal_match():
+    bands = [
+        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
+        Band(level=HEALTH_DEGRADED, min=11, max=15),
+        Band(level=HEALTH_CRITICAL, min=10, max=16),
+    ]
+    assert _band_eval(13.0, bands=bands) == HEALTH_NOMINAL
+
+
+def test_band_degraded_match():
+    bands = [
+        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
+        Band(level=HEALTH_DEGRADED, min=11, max=15),
+        Band(level=HEALTH_CRITICAL, min=10, max=16),
+    ]
+    assert _band_eval(11.5, bands=bands) == HEALTH_DEGRADED
+
+
+def test_band_critical_match():
+    bands = [
+        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
+        Band(level=HEALTH_DEGRADED, min=11, max=15),
+        Band(level=HEALTH_CRITICAL, min=10, max=16),
+    ]
+    assert _band_eval(15.5, bands=bands) == HEALTH_CRITICAL
+
+
+def test_band_no_match_uses_default_level():
+    bands = [Band(level=HEALTH_NOMINAL, min=12, max=14.5)]
+    assert (
+        _band_eval(20.0, bands=bands, default_level=HEALTH_CRITICAL) == HEALTH_CRITICAL
+    )
+
+
+def test_evaluator_combines_rate_and_tiered_content_worst_wins():
+    bands = [
+        Band(level=HEALTH_NOMINAL, min=12, max=14.5),
+        Band(level=HEALTH_CRITICAL, min=10, max=16),
+    ]
+    exp = Expectation(
+        name="batt",
+        key_expr="k/**",
+        inactive_after_s=5.0,
+        window_s=2.0,
+        publication_rate_hz=_publication_rate_hz_for(10.0, 20.0),
+        content_rules=[ContentRule(field="value", bands=bands)],
+        require_liveliness=False,
+    )
+    ev = Evaluator(exp)
+    # Healthy rate, but value lands in CRITICAL band
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1, payload=SimpleNamespace(value=15.5))
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert state.level == HEALTH_CRITICAL
+    assert "value=15.5" in state.detail
+
+
+def test_band_equals_string_match():
+    bands = [
+        Band(level=HEALTH_CRITICAL, equals="foo"),
+        Band(level=HEALTH_NOMINAL, equals=["bar", "baz"]),
+    ]
+    rule = ContentRule(field="value", bands=bands, default_level=HEALTH_DEGRADED)
+    assert rule.evaluate(SimpleNamespace(value="foo"))[0] == HEALTH_CRITICAL
+    assert rule.evaluate(SimpleNamespace(value="bar"))[0] == HEALTH_NOMINAL
+    assert rule.evaluate(SimpleNamespace(value="baz"))[0] == HEALTH_NOMINAL
+    assert rule.evaluate(SimpleNamespace(value="other"))[0] == HEALTH_DEGRADED
+
+
+def test_band_equals_bool_match():
+    bands = [Band(level=HEALTH_CRITICAL, equals=False)]
+    rule = ContentRule(field="value", bands=bands, default_level=HEALTH_NOMINAL)
+    assert rule.evaluate(SimpleNamespace(value=False))[0] == HEALTH_CRITICAL
+    assert rule.evaluate(SimpleNamespace(value=True))[0] == HEALTH_NOMINAL
+
+
+def test_protobuf_enum_matched_by_name():
+    """ContentRule should match enum fields by symbolic name via the descriptor."""
+    from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+
+    msg = LocationFixQuality()
+    msg.fix_type = LocationFixQuality.FIX_3D_RTK  # int 9
+
+    rule = ContentRule(
+        field="fix_type",
+        bands=[
+            Band(level=HEALTH_NOMINAL, equals=["FIX_3D_RTK", "FIX_3D"]),
+            Band(level=HEALTH_DEGRADED, equals=["FIX_3D_DGPS"]),
+        ],
+        default_level=HEALTH_CRITICAL,
+    )
+    assert rule.evaluate(msg)[0] == HEALTH_NOMINAL
+
+    msg.fix_type = LocationFixQuality.INVALID
+    assert rule.evaluate(msg)[0] == HEALTH_CRITICAL
+
+
+def test_protobuf_enum_still_matches_by_int():
+    from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+
+    msg = LocationFixQuality()
+    msg.fix_type = LocationFixQuality.FIX_3D_RTK
+    rule = ContentRule(
+        field="fix_type",
+        bands=[Band(level=HEALTH_NOMINAL, equals=[9])],
+        default_level=HEALTH_CRITICAL,
+    )
+    assert rule.evaluate(msg)[0] == HEALTH_NOMINAL
+
+
+def test_parse_level_accepts_strings_and_ints():
+    assert parse_level("NOMINAL") == HEALTH_NOMINAL
+    assert parse_level("HEALTH_DEGRADED") == HEALTH_DEGRADED
+    assert parse_level(HEALTH_CRITICAL) == HEALTH_CRITICAL

--- a/connectors/entity_health/tests/test_evaluator_unit.py
+++ b/connectors/entity_health/tests/test_evaluator_unit.py
@@ -283,3 +283,57 @@ def test_parse_level_accepts_strings_and_ints():
     assert parse_level("NOMINAL") == HEALTH_NOMINAL
     assert parse_level("HEALTH_DEGRADED") == HEALTH_DEGRADED
     assert parse_level(HEALTH_CRITICAL) == HEALTH_CRITICAL
+
+
+# --- measured_publication_rate_hz on SubsystemState ----------------------
+
+
+def test_measured_rate_is_zero_when_no_samples():
+    ev = _make()
+    assert ev.evaluate(now=100.0).measured_publication_rate_hz == 0.0
+
+
+def test_measured_rate_reflects_observed_rate_when_nominal():
+    ev = _make()  # window_s=2.0
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)  # 10 Hz over 2s window → 10.0 Hz
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert state.level == HEALTH_NOMINAL
+    assert state.measured_publication_rate_hz == 10.0
+
+
+def test_measured_rate_populated_when_unknown():
+    ev = _make(require_liveliness=True)
+    state = ev.evaluate(now=100.0)
+    assert state.level == HEALTH_UNKNOWN
+    assert state.measured_publication_rate_hz == 0.0
+
+
+def test_measured_rate_populated_when_inactive():
+    ev = _make(inactive_after_s=2.0)  # window_s=2.0
+    ev.record(now=100.0)
+    state = ev.evaluate(now=105.0)  # 5s of silence > 2s limit, also outside window
+    assert state.level == HEALTH_INACTIVE
+    assert state.measured_publication_rate_hz == 0.0
+
+
+def test_measured_rate_uses_sliding_window():
+    ev = _make(inactive_after_s=10.0)  # window_s=2.0
+    # Old samples that should be evicted from the rate window
+    for i in range(10):
+        ev.record(now=1000.0 + i * 0.1)
+    # Recent samples inside the 2s window: 4 samples → 2.0 Hz
+    for i in range(4):
+        ev.record(now=1004.0 + i * 0.1)
+    state = ev.evaluate(now=1004.5)
+    assert state.measured_publication_rate_hz == 2.0
+
+
+def test_measured_rate_populated_when_critical_from_rate_band():
+    ev = _make(publication_rate_hz=_publication_rate_hz_for(10.0, 20.0))
+    # 2 Hz over 2s window → outside both NOMINAL and DEGRADED bands → CRITICAL
+    for i in range(4):
+        ev.record(now=1000.0 + i * 0.5)
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert state.level == HEALTH_CRITICAL
+    assert state.measured_publication_rate_hz == 2.0

--- a/connectors/entity_health/tests/test_evaluator_unit.py
+++ b/connectors/entity_health/tests/test_evaluator_unit.py
@@ -4,9 +4,11 @@ from types import SimpleNamespace
 
 from entity_health.evaluator import (
     Band,
+    CheckResult,
     ContentRule,
     Evaluator,
     Expectation,
+    SourceState,
     evaluate_all,
     parse_level,
     HEALTH_CRITICAL,
@@ -45,9 +47,11 @@ def test_no_samples_without_liveliness_required_is_inactive():
 
 
 def test_no_liveliness_token_is_unknown():
+    """Liveliness failure is conveyed by source.level=UNKNOWN with empty checks."""
     ev = _make(require_liveliness=True)
-    assert ev.evaluate(now=100.0).level == HEALTH_UNKNOWN
-    assert "liveliness" in ev.evaluate(now=100.0).detail
+    state = ev.evaluate(now=100.0)
+    assert state.level == HEALTH_UNKNOWN
+    assert state.checks == []
 
 
 def test_liveliness_present_no_samples_is_inactive():
@@ -55,7 +59,9 @@ def test_liveliness_present_no_samples_is_inactive():
     ev.set_alive("k/a")
     state = ev.evaluate(now=100.0)
     assert state.level == HEALTH_INACTIVE
-    assert "alive but no samples" in state.detail
+    activity = next(c for c in state.checks if c.name == "activity")
+    assert activity.level == HEALTH_INACTIVE
+    assert "alive but no samples" in activity.detail
 
 
 def test_liveliness_present_with_data_is_nominal():
@@ -98,7 +104,10 @@ def test_silence_beyond_inactive_after_is_inactive():
     ev.record(now=100.0)
     state = ev.evaluate(now=105.0)
     assert state.level == HEALTH_INACTIVE
-    assert "silent" in state.detail
+    activity = next(c for c in state.checks if c.name == "activity")
+    assert activity.level == HEALTH_INACTIVE
+    assert "silent" in activity.detail
+    assert "limit 2.0s" in activity.detail
 
 
 def test_rate_in_degraded_band():
@@ -134,7 +143,8 @@ def test_content_rule_out_of_range_uses_default_level():
         ev.record(now=1000.0 + i * 0.1, payload=SimpleNamespace(latitude=200.0))
     state = ev.evaluate(now=1000.0 + 2.0)
     assert state.level == HEALTH_CRITICAL
-    assert "latitude" in state.detail
+    lat = next(c for c in state.checks if c.name == "latitude")
+    assert "latitude" in lat.detail
 
 
 def test_content_rule_in_range_is_nominal():
@@ -223,7 +233,8 @@ def test_evaluator_combines_rate_and_tiered_content_worst_wins():
         ev.record(now=1000.0 + i * 0.1, payload=SimpleNamespace(value=15.5))
     state = ev.evaluate(now=1000.0 + 2.0)
     assert state.level == HEALTH_CRITICAL
-    assert "value=15.5" in state.detail
+    value_check = next(c for c in state.checks if c.name == "value")
+    assert "value=15.5" in value_check.detail
 
 
 def test_band_equals_string_match():
@@ -327,6 +338,158 @@ def test_measured_rate_uses_sliding_window():
         ev.record(now=1004.0 + i * 0.1)
     state = ev.evaluate(now=1004.5)
     assert state.measured_publication_rate_hz == 2.0
+
+
+# --- proto schema -------------------------------------------------------
+
+
+def test_protobuf_source_health_has_checks_field():
+    """SourceHealth proto must expose a repeated CheckResult `checks` field."""
+    from keelson.payloads.EntityHealth_pb2 import (
+        CheckResult as ProtoCheckResult,
+        SourceHealth,
+        HEALTH_NOMINAL as PROTO_NOMINAL,
+    )
+
+    sh = SourceHealth()
+    cr = sh.checks.add()
+    cr.name = "publication_rate"
+    cr.level = PROTO_NOMINAL
+    cr.detail = "ok"
+    assert sh.checks[0].name == "publication_rate"
+    assert sh.checks[0].level == PROTO_NOMINAL
+    assert isinstance(sh.checks[0], ProtoCheckResult)
+
+
+# --- gate semantics: liveliness vs activity -----------------------------
+
+
+def test_unknown_gate_emits_no_checks():
+    """Liveliness failure: source.level=UNKNOWN, checks empty, no detail elsewhere."""
+    ev = _make(require_liveliness=True)
+    state = ev.evaluate(now=100.0)
+    assert state.level == HEALTH_UNKNOWN
+    assert state.checks == []
+
+
+def test_inactive_no_samples_emits_only_activity_check():
+    """Activity gate failure: only the activity check is emitted."""
+    ev = _make(require_liveliness=True)
+    ev.set_alive("k/a")
+    state = ev.evaluate(now=100.0)
+    assert state.level == HEALTH_INACTIVE
+    assert [c.name for c in state.checks] == ["activity"]
+    assert state.checks[0].level == HEALTH_INACTIVE
+    assert state.checks[0].detail == "alive but no samples received yet"
+
+
+def test_inactive_silent_emits_only_activity_check():
+    ev = _make(inactive_after_s=2.0)
+    ev.record(now=100.0)
+    state = ev.evaluate(now=105.0)
+    assert state.level == HEALTH_INACTIVE
+    assert [c.name for c in state.checks] == ["activity"]
+    assert state.checks[0].level == HEALTH_INACTIVE
+    assert state.checks[0].detail.startswith("silent for ")
+    assert "limit 2.0s" in state.checks[0].detail
+
+
+def test_full_eval_includes_activity_as_nominal():
+    """When activity gate passes, activity is still in checks at NOMINAL."""
+    ev = _make()
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert state.level == HEALTH_NOMINAL
+    activity = next(c for c in state.checks if c.name == "activity")
+    assert activity.level == HEALTH_NOMINAL
+    assert activity.detail == ""
+
+
+# --- checks[] population on full-eval path ------------------------------
+
+
+def _check_by_name(checks: list[CheckResult], name: str) -> CheckResult | None:
+    return next((c for c in checks if c.name == name), None)
+
+
+def test_checks_contains_activity_and_publication_rate_when_no_content_rules():
+    ev = _make()
+    for i in range(20):
+        ev.record(now=1000.0 + i * 0.1)
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert [c.name for c in state.checks] == ["activity", "publication_rate"]
+    assert all(c.level == HEALTH_NOMINAL for c in state.checks)
+
+
+def test_checks_includes_one_entry_per_content_rule_named_after_field():
+    """gnss-style expectation → 4 checks (activity + rate + latitude + longitude), all NOMINAL."""
+    lat_rule = ContentRule(
+        field="latitude",
+        bands=[Band(level=HEALTH_NOMINAL, min=-90, max=90)],
+        default_level=HEALTH_CRITICAL,
+    )
+    lon_rule = ContentRule(
+        field="longitude",
+        bands=[Band(level=HEALTH_NOMINAL, min=-180, max=180)],
+        default_level=HEALTH_CRITICAL,
+    )
+    ev = _make(content_rules=[lat_rule, lon_rule])
+    for i in range(20):
+        ev.record(
+            now=1000.0 + i * 0.1,
+            payload=SimpleNamespace(latitude=45.0, longitude=10.0),
+        )
+    state = ev.evaluate(now=1000.0 + 2.0)
+    assert [c.name for c in state.checks] == [
+        "activity",
+        "publication_rate",
+        "latitude",
+        "longitude",
+    ]
+    assert all(c.level == HEALTH_NOMINAL for c in state.checks)
+
+
+def test_checks_carry_per_check_levels_and_details_when_mixed():
+    """One content rule fails CRITICAL, the other stays NOMINAL → checks[] reflects both."""
+    lat_rule = ContentRule(
+        field="latitude",
+        bands=[Band(level=HEALTH_NOMINAL, min=-90, max=90)],
+        default_level=HEALTH_CRITICAL,
+    )
+    lon_rule = ContentRule(
+        field="longitude",
+        bands=[Band(level=HEALTH_NOMINAL, min=-180, max=180)],
+        default_level=HEALTH_CRITICAL,
+    )
+    ev = _make(content_rules=[lat_rule, lon_rule])
+    for i in range(20):
+        ev.record(
+            now=1000.0 + i * 0.1,
+            payload=SimpleNamespace(latitude=200.0, longitude=10.0),
+        )
+    state = ev.evaluate(now=1000.0 + 2.0)
+    lat = _check_by_name(state.checks, "latitude")
+    lon = _check_by_name(state.checks, "longitude")
+    rate = _check_by_name(state.checks, "publication_rate")
+    assert lat is not None and lat.level == HEALTH_CRITICAL
+    assert "latitude" in lat.detail
+    assert lon is not None and lon.level == HEALTH_NOMINAL
+    assert lon.detail == ""
+    assert rate is not None and rate.level == HEALTH_NOMINAL
+
+
+def test_source_state_has_empty_checks_by_default():
+    """SourceState should expose a `checks` list, defaulting to empty."""
+    state = SourceState(name="x", level=HEALTH_NOMINAL)
+    assert state.checks == []
+
+
+def test_check_result_is_a_dataclass_with_name_level_detail():
+    cr = CheckResult(name="publication_rate", level=HEALTH_NOMINAL)
+    assert cr.name == "publication_rate"
+    assert cr.level == HEALTH_NOMINAL
+    assert cr.detail == ""
 
 
 def test_measured_rate_populated_when_critical_from_rate_band():

--- a/connectors/entity_health/tests/test_set_config_unit.py
+++ b/connectors/entity_health/tests/test_set_config_unit.py
@@ -3,14 +3,22 @@
 Exercises the reconfiguration code path by faking the Zenoh session.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from keelson import construct_pubsub_key
 
 
 def test_set_config_without_session_updates_config(entity_health_module):
     mod = entity_health_module
     new = {
         "publish_rate_hz": 2.0,
-        "expectations": [{"name": "a", "key_expr": "r/**", "inactive_after_s": 5.0}],
+        "sources": [
+            {
+                "name": "dev1",
+                "subjects": [{"name": "a", "inactive_after_s": 5.0}],
+            }
+        ],
     }
     mod.set_config(new)
     assert mod.get_config()["publish_rate_hz"] == 2.0
@@ -20,6 +28,7 @@ def test_set_config_with_session_declares_subscribers(entity_health_module):
     mod = entity_health_module
 
     subs: list[MagicMock] = []
+    liveliness_subs: list[MagicMock] = []
 
     def _declare_subscriber(key_expr, handler):
         sub = MagicMock()
@@ -27,32 +36,132 @@ def test_set_config_with_session_declares_subscribers(entity_health_module):
         subs.append(sub)
         return sub
 
+    def _declare_liveliness_subscriber(key_expr, handler, history=False):
+        sub = MagicMock()
+        sub.key_expr = key_expr
+        liveliness_subs.append(sub)
+        return sub
+
     session = MagicMock()
     session.declare_subscriber.side_effect = _declare_subscriber
+    session.liveliness().declare_subscriber.side_effect = _declare_liveliness_subscriber
     mod.SESSION = session
+    mod.ARGS = SimpleNamespace(realm="r", entity_id="e", source_id="health")
 
     mod.set_config(
         {
             "publish_rate_hz": 1.0,
-            "expectations": [
-                {"name": "a", "key_expr": "r/a/**", "inactive_after_s": 5.0},
-                {"name": "b", "key_expr": "r/b/**", "inactive_after_s": 5.0},
+            "sources": [
+                {
+                    "name": "dev1",
+                    "subjects": [
+                        {"name": "a", "inactive_after_s": 5.0},
+                        {"name": "b", "inactive_after_s": 5.0},
+                    ],
+                },
+                {
+                    "name": "dev2",
+                    "subjects": [{"name": "a", "inactive_after_s": 5.0}],
+                },
             ],
         }
     )
-    assert set(mod.SUBSCRIBERS.keys()) == {"a", "b"}
-    assert set(mod.EVALUATORS.keys()) == {"a", "b"}
-    assert len(subs) == 2
+    assert set(mod.SUBSCRIBERS.keys()) == {("dev1", "a"), ("dev1", "b"), ("dev2", "a")}
+    assert set(mod.EVALUATORS.keys()) == {("dev1", "a"), ("dev1", "b"), ("dev2", "a")}
+    # key_expr should be exactly what construct_pubsub_key produces — pin the
+    # contract, not a substring of it.
+    assert mod.SUBSCRIBERS[("dev1", "a")].key_expr == construct_pubsub_key(
+        "r", "e", "a", "dev1"
+    )
+    assert mod.SUBSCRIBERS[("dev1", "b")].key_expr == construct_pubsub_key(
+        "r", "e", "b", "dev1"
+    )
+    assert mod.SUBSCRIBERS[("dev2", "a")].key_expr == construct_pubsub_key(
+        "r", "e", "a", "dev2"
+    )
 
-    # Reconfigure: drop "b", keep "a", add "c"
+    # Reconfigure: drop dev1/b, keep the others, add dev2/c
     mod.set_config(
         {
             "publish_rate_hz": 1.0,
-            "expectations": [
-                {"name": "a", "key_expr": "r/a/**", "inactive_after_s": 5.0},
-                {"name": "c", "key_expr": "r/c/**", "inactive_after_s": 5.0},
+            "sources": [
+                {
+                    "name": "dev1",
+                    "subjects": [{"name": "a", "inactive_after_s": 5.0}],
+                },
+                {
+                    "name": "dev2",
+                    "subjects": [
+                        {"name": "a", "inactive_after_s": 5.0},
+                        {"name": "c", "inactive_after_s": 5.0},
+                    ],
+                },
             ],
         }
     )
-    assert set(mod.SUBSCRIBERS.keys()) == {"a", "c"}
-    assert "b" not in mod.EVALUATORS
+    assert set(mod.SUBSCRIBERS.keys()) == {("dev1", "a"), ("dev2", "a"), ("dev2", "c")}
+    assert ("dev1", "b") not in mod.EVALUATORS
+
+
+def test_set_config_uses_realm_entity_from_config_when_present(entity_health_module):
+    """Config-supplied realm/entity_id should override CLI args for monitored keys."""
+    mod = entity_health_module
+
+    captured: list[str] = []
+
+    def _declare_subscriber(key_expr, handler):
+        captured.append(key_expr)
+        sub = MagicMock()
+        sub.key_expr = key_expr
+        return sub
+
+    session = MagicMock()
+    session.declare_subscriber.side_effect = _declare_subscriber
+    session.liveliness().declare_subscriber.return_value = MagicMock()
+    mod.SESSION = session
+    mod.ARGS = SimpleNamespace(
+        realm="cli_realm", entity_id="cli_entity", source_id="health"
+    )
+
+    mod.set_config(
+        {
+            "publish_rate_hz": 1.0,
+            "realm": "cfg_realm",
+            "entity_id": "cfg_entity",
+            "sources": [
+                {"name": "dev1", "subjects": [{"name": "a"}]},
+            ],
+        }
+    )
+    # Every captured key must use the config-supplied realm/entity, not just one.
+    assert captured, "expected at least one subscriber declaration"
+    assert all("cfg_realm" in k and "cfg_entity" in k for k in captured)
+    assert not any("cli_realm" in k for k in captured)
+
+
+def test_set_config_falls_back_to_cli_realm_entity(entity_health_module):
+    mod = entity_health_module
+
+    captured: list[str] = []
+
+    def _declare_subscriber(key_expr, handler):
+        captured.append(key_expr)
+        sub = MagicMock()
+        sub.key_expr = key_expr
+        return sub
+
+    session = MagicMock()
+    session.declare_subscriber.side_effect = _declare_subscriber
+    session.liveliness().declare_subscriber.return_value = MagicMock()
+    mod.SESSION = session
+    mod.ARGS = SimpleNamespace(
+        realm="cli_realm", entity_id="cli_entity", source_id="health"
+    )
+
+    mod.set_config(
+        {
+            "publish_rate_hz": 1.0,
+            "sources": [{"name": "dev1", "subjects": [{"name": "a"}]}],
+        }
+    )
+    assert all("cli_realm" in k and "cli_entity" in k for k in captured)

--- a/connectors/entity_health/tests/test_set_config_unit.py
+++ b/connectors/entity_health/tests/test_set_config_unit.py
@@ -1,0 +1,58 @@
+"""In-process test of set_config() without Zenoh.
+
+Exercises the reconfiguration code path by faking the Zenoh session.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_set_config_without_session_updates_config(entity_health_module):
+    mod = entity_health_module
+    new = {
+        "publish_rate_hz": 2.0,
+        "expectations": [{"name": "a", "key_expr": "r/**", "inactive_after_s": 5.0}],
+    }
+    mod.set_config(new)
+    assert mod.get_config()["publish_rate_hz"] == 2.0
+
+
+def test_set_config_with_session_declares_subscribers(entity_health_module):
+    mod = entity_health_module
+
+    subs: list[MagicMock] = []
+
+    def _declare_subscriber(key_expr, handler):
+        sub = MagicMock()
+        sub.key_expr = key_expr
+        subs.append(sub)
+        return sub
+
+    session = MagicMock()
+    session.declare_subscriber.side_effect = _declare_subscriber
+    mod.SESSION = session
+
+    mod.set_config(
+        {
+            "publish_rate_hz": 1.0,
+            "expectations": [
+                {"name": "a", "key_expr": "r/a/**", "inactive_after_s": 5.0},
+                {"name": "b", "key_expr": "r/b/**", "inactive_after_s": 5.0},
+            ],
+        }
+    )
+    assert set(mod.SUBSCRIBERS.keys()) == {"a", "b"}
+    assert set(mod.EVALUATORS.keys()) == {"a", "b"}
+    assert len(subs) == 2
+
+    # Reconfigure: drop "b", keep "a", add "c"
+    mod.set_config(
+        {
+            "publish_rate_hz": 1.0,
+            "expectations": [
+                {"name": "a", "key_expr": "r/a/**", "inactive_after_s": 5.0},
+                {"name": "c", "key_expr": "r/c/**", "inactive_after_s": 5.0},
+            ],
+        }
+    )
+    assert set(mod.SUBSCRIBERS.keys()) == {"a", "c"}
+    assert "b" not in mod.EVALUATORS

--- a/connectors/nmea/requirements.txt
+++ b/connectors/nmea/requirements.txt
@@ -1,4 +1,7 @@
 keelson
 pynmea2>=1.19.0
-nmea2000>=2025.10.13
+# TODO: nmea2000 2026.3+ renamed ActisenseNmea2000Gateway -> ActisenseBstNmea2000Gateway
+# and removed YachtDevicesNmea2000Gateway (use TextNmea2000Gateway). Migrate n2k-cli.py
+# and drop this upper bound.
+nmea2000>=2025.10.13,<2026.0.0
 skarv>=0.3.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,13 @@ RUN pip install --no-cache-dir \
     -r /build/reqs/nmea.txt \
     -r /build/reqs/platform.txt \
     -r /build/reqs/rtcm.txt \
-    -r /build/reqs/entity_health.txt \
+    -r /build/reqs/entity_health.txt
+
+# entity_health ships an importable Python sub-package alongside its bin
+# script, so install the connector itself (not just its requirements) so
+# `import entity_health.evaluator` works from /usr/local/bin/.
+COPY connectors/entity_health /build/entity_health
+RUN pip install --no-cache-dir --no-deps /build/entity_health \
     && rm -rf /build
 
 # Copy all connector scripts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ COPY connectors/mockups/requirements.txt /build/reqs/mockups.txt
 COPY connectors/nmea/requirements.txt /build/reqs/nmea.txt
 COPY connectors/platform/requirements.txt /build/reqs/platform.txt
 COPY connectors/rtcm/requirements.txt /build/reqs/rtcm.txt
+COPY connectors/entity_health/requirements.txt /build/reqs/entity_health.txt
 
 RUN pip install --no-cache-dir \
     -r /build/reqs/ais.txt \
@@ -34,6 +35,7 @@ RUN pip install --no-cache-dir \
     -r /build/reqs/nmea.txt \
     -r /build/reqs/platform.txt \
     -r /build/reqs/rtcm.txt \
+    -r /build/reqs/entity_health.txt \
     && rm -rf /build
 
 # Copy all connector scripts
@@ -47,6 +49,7 @@ COPY connectors/mockups/bin/*.py /usr/local/bin/
 COPY connectors/nmea/bin/*.py /usr/local/bin/
 COPY connectors/platform/bin/*.py /usr/local/bin/
 COPY connectors/rtcm/bin/*.py /usr/local/bin/
+COPY connectors/entity_health/bin/*.py /usr/local/bin/
 
 # Rename scripts (remove .py extension) and ensure executable
 RUN for f in /usr/local/bin/*.py; do \

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -11,11 +11,17 @@ enum HealthLevel {
   HEALTH_NOMINAL  = 4;
 }
 
+message CheckResult {
+  string      name   = 1;
+  HealthLevel level  = 2;
+  string      detail = 3;
+}
+
 message SourceHealth {
-  string      name                        = 1;
-  HealthLevel level                       = 2;
-  string      detail                      = 3;
-  float       measured_publication_rate_hz = 4;
+  string               name                         = 1;
+  HealthLevel          level                        = 2;
+  float                measured_publication_rate_hz = 3;
+  repeated CheckResult checks                       = 4;
 }
 
 message EntityHealth {

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -11,7 +11,7 @@ enum HealthLevel {
   HEALTH_NOMINAL  = 4;
 }
 
-message SubsystemHealth {
+message SourceHealth {
   string      name   = 1;
   HealthLevel level  = 2;
   string      detail = 3;
@@ -21,5 +21,5 @@ message EntityHealth {
   google.protobuf.Timestamp  timestamp  = 1;
   HealthLevel                level      = 2;
   float                      rate_hz    = 3;
-  repeated SubsystemHealth   subsystems = 6;
+  repeated SourceHealth      sources    = 6;
 }

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -17,7 +17,7 @@ message CheckResult {
   string      detail = 3;
 }
 
-message SourceHealth {
+message SubjectHealth {
   string               name                         = 1;
   HealthLevel          level                        = 2;
   float                measured_publication_rate_hz = 3;
@@ -28,5 +28,5 @@ message EntityHealth {
   google.protobuf.Timestamp  timestamp  = 1;
   HealthLevel                level      = 2;
   float                      rate_hz    = 3;
-  repeated SourceHealth      sources    = 6;
+  repeated SubjectHealth     subjects   = 6;
 }

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -12,9 +12,10 @@ enum HealthLevel {
 }
 
 message SourceHealth {
-  string      name   = 1;
-  HealthLevel level  = 2;
-  string      detail = 3;
+  string      name                        = 1;
+  HealthLevel level                       = 2;
+  string      detail                      = 3;
+  float       measured_publication_rate_hz = 4;
 }
 
 message EntityHealth {

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package keelson;
+
+import "google/protobuf/timestamp.proto";
+
+enum HealthLevel {
+  HEALTH_UNKNOWN  = 0;
+  HEALTH_INACTIVE = 1;
+  HEALTH_CRITICAL = 2;
+  HEALTH_DEGRADED = 3;
+  HEALTH_NOMINAL  = 4;
+}
+
+message SubsystemHealth {
+  string      name   = 1;
+  HealthLevel level  = 2;
+  string      detail = 3;
+}
+
+message EntityHealth {
+  google.protobuf.Timestamp  timestamp  = 1;
+  HealthLevel                level      = 2;
+  float                      rate_hz    = 3;
+  repeated SubsystemHealth   subsystems = 6;
+}

--- a/messages/payloads/EntityHealth.proto
+++ b/messages/payloads/EntityHealth.proto
@@ -24,9 +24,15 @@ message SubjectHealth {
   repeated CheckResult checks                       = 4;
 }
 
+message SourceHealth {
+  string                 name     = 1;
+  HealthLevel            level    = 2;
+  repeated SubjectHealth subjects = 3;
+}
+
 message EntityHealth {
   google.protobuf.Timestamp  timestamp  = 1;
   HealthLevel                level      = 2;
   float                      rate_hz    = 3;
-  repeated SubjectHealth     subjects   = 6;
+  repeated SourceHealth      sources    = 4;
 }

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -15,6 +15,7 @@ network_status:                         keelson.NetworkStatus
 simulation_status:                      keelson.SimulationStatus
 roc_status:                             keelson.ROCStatus
 operational_authority:                  keelson.OperationalAuthority
+entity_health:                          keelson.EntityHealth 
 
 frame_transform:                        foxglove.FrameTransform
 
@@ -194,6 +195,6 @@ heading_accuracy_deg:                   keelson.TimestampedFloat # 1-sigma headi
 gnss_aiding_status:                     keelson.TimestampedInt   # 0=GPS only, 1=GPS+inertial
 imu_system_status:                      keelson.TimestampedInt   # 0=good, non-zero=error codes
 
-# Flying stuff 
+# Flying stuff
 altitude_above_msl_m:                   keelson.TimestampedFloat
 climb_rate_mps:                         keelson.TimestampedFloat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "keelson-connector-ais",
     "keelson-connector-camera",
     "keelson-connector-rtcm",
+    "keelson-connector-entity-health",
 ]
 
 [tool.uv.sources]
@@ -28,6 +29,7 @@ keelson-connector-platform = { workspace = true }
 keelson-connector-ais = { workspace = true }
 keelson-connector-camera = { workspace = true }
 keelson-connector-rtcm = { workspace = true }
+keelson-connector-entity-health = { workspace = true }
 
 [tool.uv.workspace]
 members = [
@@ -42,6 +44,7 @@ members = [
     "connectors/ais",
     "connectors/camera",
     "connectors/rtcm",
+    "connectors/entity_health",
 ]
 
 [dependency-groups]
@@ -70,6 +73,7 @@ testpaths = [
     "connectors/ais/tests",
     "connectors/camera/tests",
     "connectors/rtcm/tests",
+    "connectors/entity_health/tests",
 ]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ members = [
     "keelson",
     "keelson-connector-ais",
     "keelson-connector-camera",
+    "keelson-connector-entity-health",
     "keelson-connector-foxglove",
     "keelson-connector-klog",
     "keelson-connector-mcap",
@@ -499,6 +500,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "keelson-connector-entity-health"
+version = "0.0.0"
+source = { editable = "connectors/entity_health" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "keelson" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jsonschema", specifier = ">=4.20.0" },
+    { name = "keelson", editable = "sdks/python" },
+]
+
+[[package]]
 name = "keelson-connector-foxglove"
 version = "0.0.0"
 source = { editable = "connectors/foxglove" }
@@ -636,6 +652,7 @@ dependencies = [
     { name = "keelson" },
     { name = "keelson-connector-ais" },
     { name = "keelson-connector-camera" },
+    { name = "keelson-connector-entity-health" },
     { name = "keelson-connector-foxglove" },
     { name = "keelson-connector-klog" },
     { name = "keelson-connector-mcap" },
@@ -664,6 +681,7 @@ requires-dist = [
     { name = "keelson", editable = "sdks/python" },
     { name = "keelson-connector-ais", editable = "connectors/ais" },
     { name = "keelson-connector-camera", editable = "connectors/camera" },
+    { name = "keelson-connector-entity-health", editable = "connectors/entity_health" },
     { name = "keelson-connector-foxglove", editable = "connectors/foxglove" },
     { name = "keelson-connector-klog", editable = "connectors/klog" },
     { name = "keelson-connector-mcap", editable = "connectors/mcap" },


### PR DESCRIPTION
Introduces a new connector that subscribes to configurable Zenoh key-expressions, evaluates publication rate, content rules and liveliness against tiered bands, and publishes an aggregated keelson.EntityHealth message. Reconfigurable at runtime via the Configurable RPC interface.