### PR TITLE
NMEA 2000 AIS support: keelson2n2k inject + n2k2keelson decode

### DIFF
--- a/connectors/nmea/README.md
+++ b/connectors/nmea/README.md
@@ -127,7 +127,9 @@ uv run python connectors/nmea/bin/keelson2nmea0183.py \
 
 Opens a CAN gateway, decodes NMEA2000 frames, and publishes the extracted data to Keelson subjects on the Zenoh bus.
 
-Supported PGNs: 129025 (Position), 129026 (COG & SOG), 129029 (GNSS), 127250 (Heading), 127257 (Attitude), 130306 (Wind), 127245 (Rudder), 130311 (Environmental).
+Supported PGNs: 129025 (Position), 129026 (COG & SOG), 129029 (GNSS), 127250 (Heading), 127257 (Attitude), 130306 (Wind), 127245 (Rudder), 130311 (Environmental), 129038 (AIS Class A position), 129039 (AIS Class B position), 129794 (AIS Class A static & voyage).
+
+AIS reports (129038/129039/129794) are published per observed vessel, scoped with the `target_id` `mmsi_<MMSI>`.
 
 ### Gateway profiles
 
@@ -207,14 +209,28 @@ uv run python connectors/nmea/bin/n2k2keelson.py \
 
 Subscribes to Keelson subjects on the Zenoh bus, aggregates data using skarv, generates NMEA2000 messages, and injects them into a CAN gateway.
 
-Generated PGNs: 129025, 129026, 129029, 127250, 127257, 130306, 127245, 130311.
+Generated PGNs: 129025, 129026, 129029, 127250, 127257, 130306, 127245, 130311. With `--inject-as`, also 129038 / 129794 (AIS).
 
 `--gateway` selects a named gateway profile (`yden02`, `ebyte`, `actisense`, `waveshare`, `actisense_ngx1`) — see the [`n2k2keelson` gateway profiles](#gateway-profiles) table. On connect the gateway's identity is probed and logged; note that a *polite* gateway (YDEN-02, Actisense) rewrites the source address of injected frames to its own claimed address, so verify injection on payload-internal markers rather than the source address.
+
+### AIS injection (`--inject-as`)
+
+`keelson2n2k` reads exactly one vessel off the bus. `--inject-as` chooses how that vessel is rendered onto the N2K bus:
+
+| `--inject-as` | Injects | Use |
+|---|---|---|
+| `ownship` *(default)* | the 8 general instrument PGNs | the vessel **is** the bus's own ship — today's behavior |
+| `ownship-ais` | general PGNs **+** AIS 129038/129794 | the own ship, plus its AIS transponder broadcast |
+| `ais-target` | AIS 129038/129794 **only** | the vessel appears as an AIS **contact**; no general PGNs |
+
+The AIS modes need the own-ship `mmsi_number` subject; AIS PGNs are skipped (with a warning) while it is absent. 129038 is emitted on `location_fix` updates; 129794 (static & voyage data) is re-sent every `--ais-static-period` seconds. Only Class A AIS is supported — every injected target renders as Class A.
 
 ```
 usage: keelson2n2k [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
                    [--connect CONNECT] [--listen LISTEN] -r REALM -e ENTITY_ID
                    [--source-address SOURCE_ADDRESS] [--priority PRIORITY]
+                   [--inject-as {ownship,ownship-ais,ais-target}]
+                   [--ais-static-period AIS_STATIC_PERIOD]
                    --gateway {actisense,actisense_ngx1,ebyte,waveshare,yden02}
                    [--host HOST] [--port PORT] [--device DEVICE]
                    [--ensure-baud ENSURE_BAUD] [--persist]
@@ -239,6 +255,13 @@ options:
   --source_id_<subject> SOURCE_ID
                         Source ID pattern for each subject (supports wildcards)
 
+NMEA 2000 output:
+  --inject-as {ownship,ownship-ais,ais-target}
+                        What to inject for the vessel read off the bus
+                        (default: ownship).
+  --ais-static-period AIS_STATIC_PERIOD
+                        Seconds between PGN 129794 emissions (default: 300).
+
 CAN gateway:
   --gateway {actisense,actisense_ngx1,ebyte,waveshare,yden02}
                         CAN gateway profile to inject into.
@@ -258,4 +281,16 @@ CAN gateway:
 uv run python connectors/nmea/bin/keelson2n2k.py \
   -r rise -e my_vessel \
   --gateway yden02 --host 192.168.4.1 --port 1457
+
+# Own-ship nav data plus the vessel's own AIS report
+uv run python connectors/nmea/bin/keelson2n2k.py \
+  -r rise -e my_vessel \
+  --gateway yden02 --host 192.168.4.1 --port 1457 \
+  --inject-as ownship-ais
+
+# Inject another vessel so it shows up as an AIS contact
+uv run python connectors/nmea/bin/keelson2n2k.py \
+  -r rise -e other_vessel \
+  --gateway yden02 --host 192.168.4.1 --port 1457 \
+  --inject-as ais-target
 ```

--- a/connectors/nmea/bin/keelson2n2k.py
+++ b/connectors/nmea/bin/keelson2n2k.py
@@ -15,6 +15,10 @@ Generated PGN types:
 - 130306: Wind Data
 - 127245: Rudder
 - 130311: Environmental Parameters
+
+AIS PGN types (ownship-ais / ais-target modes — see --inject-as):
+- 129038: AIS Class A Position Report
+- 129794: AIS Class A Static and Voyage Related Data
 """
 
 import sys
@@ -64,6 +68,33 @@ SUBJECTS = [
     "water_temperature_celsius",
     "air_pressure_pa",
 ]
+
+# Vessel-identity subjects consumed for AIS injection; mirrored only when
+# --inject-as selects an AIS mode (ownship-ais or ais-target).
+AIS_SUBJECTS = [
+    "mmsi_number",
+    "nav_status",
+    "name",
+    "call_sign",
+    "imo_number",
+    "vessel_type",
+    "destination",
+    "eta",
+    "length_over_all_m",
+    "breadth_over_all_m",
+    "draught_mean_m",
+]
+
+# PGNs injected in each --inject-as mode. emit() drops anything a generator
+# produces that the active mode does not cover, so an ais-target run can never
+# leak a 129025 even though location_fix still fires that generator.
+GENERAL_PGNS = {129025, 129026, 129029, 127250, 127257, 130306, 127245, 130311}
+AIS_PGNS = {129038, 129794}
+MODE_PGNS = {
+    "ownship": GENERAL_PGNS,
+    "ownship-ais": GENERAL_PGNS | AIS_PGNS,
+    "ais-target": AIS_PGNS,
+}
 
 
 def quality_to_n2k_method(quality: LocationFixQuality) -> int:
@@ -173,6 +204,51 @@ PGN_REQUIRED_FIELDS = {
         "humidity",
         "atmosphericPressure",
     ],
+    129038: [
+        "messageId",
+        "repeatIndicator",
+        "userId",
+        "longitude",
+        "latitude",
+        "positionAccuracy",
+        "raim",
+        "timeStamp",
+        "cog",
+        "sog",
+        "communicationState",
+        "aisTransceiverInformation",
+        "heading",
+        "rateOfTurn",
+        "navStatus",
+        "specialManeuverIndicator",
+        "reserved_206",
+        "spare18",
+        "reserved_211",
+        "sequenceId",
+    ],
+    129794: [
+        "messageId",
+        "repeatIndicator",
+        "userId",
+        "imoNumber",
+        "callsign",
+        "name",
+        "typeOfShip",
+        "length",
+        "beam",
+        "positionReferenceFromStarboard",
+        "positionReferenceFromBow",
+        "etaDate",
+        "etaTime",
+        "draft",
+        "destination",
+        "aisVersionIndicator",
+        "gnssType",
+        "dte",
+        "reserved_591",
+        "aisTransceiverInformation",
+        "reserved_597",
+    ],
 }
 
 # The LOOKUP-type fields among PGN_REQUIRED_FIELDS. A LOOKUP field rejects
@@ -188,6 +264,17 @@ _LOOKUP_FILLERS = {
     "directionOrder",
     "temperatureSource",
     "humiditySource",
+    # AIS PGN 129038 / 129794 LOOKUP fields.
+    "repeatIndicator",
+    "positionAccuracy",
+    "raim",
+    "timeStamp",
+    "aisTransceiverInformation",
+    "navStatus",
+    "specialManeuverIndicator",
+    "typeOfShip",
+    "aisVersionIndicator",
+    "dte",
 }
 
 
@@ -249,7 +336,12 @@ def _report_injection(pgn, future) -> None:
 
 def emit(msg):
     """Inject a generated NMEA2000 message into the CAN gateway."""
-    if msg is None or RUNNER is None:
+    if msg is None or RUNNER is None or ARGS is None:
+        return
+    # Drop any PGN the active --inject-as mode does not cover, so a generator
+    # firing on a shared trigger (e.g. location_fix) cannot leak a PGN this
+    # mode must not emit.
+    if msg.PGN not in MODE_PGNS.get(ARGS.inject_as, GENERAL_PGNS | AIS_PGNS):
         return
     # The encode + transmit happens later on the gateway thread. Attach a
     # done-callback so transmit failures are reported back to this connector's
@@ -674,6 +766,270 @@ def generate_pgn_130311():
         )
 
 
+@skarv.trigger("location_fix")
+def generate_pgn_129038():
+    """
+    Generate PGN 129038: AIS Class A Position Report
+    Triggered when location_fix updates, in the ownship-ais / ais-target modes.
+    """
+    if ARGS is None or ARGS.inject_as not in ("ownship-ais", "ais-target"):
+        return
+
+    location_sample = skarv.get("location_fix")
+    if not location_sample:
+        return
+    mmsi_sample = skarv.get("mmsi_number")
+    if not mmsi_sample:
+        logger.warning("No mmsi_number available; skipping PGN 129038")
+        return
+
+    location = unpack(location_sample)
+    mmsi = unpack(mmsi_sample)
+    if not location or not mmsi:
+        return
+
+    fields = [
+        NMEA2000Field(id="messageId", name="Message ID", raw_value=1),
+        NMEA2000Field(id="userId", name="User ID", value=mmsi.value),
+        NMEA2000Field(
+            id="latitude",
+            name="Latitude",
+            value=location.latitude,
+            unit_of_measurement="deg",
+        ),
+        NMEA2000Field(
+            id="longitude",
+            name="Longitude",
+            value=location.longitude,
+            unit_of_measurement="deg",
+        ),
+    ]
+
+    cog_sample = skarv.get("course_over_ground_deg")
+    if cog_sample:
+        cog = unpack(cog_sample)
+        if cog:
+            fields.append(
+                NMEA2000Field(
+                    id="cog",
+                    name="COG",
+                    value=cog.value * 3.14159265359 / 180.0,
+                    unit_of_measurement="rad",
+                )
+            )
+
+    sog_sample = skarv.get("speed_over_ground_knots")
+    if sog_sample:
+        sog = unpack(sog_sample)
+        if sog:
+            fields.append(
+                NMEA2000Field(
+                    id="sog",
+                    name="SOG",
+                    value=sog.value / 1.94384,
+                    unit_of_measurement="m/s",
+                )
+            )
+
+    heading_sample = skarv.get("heading_true_north_deg")
+    if heading_sample:
+        heading = unpack(heading_sample)
+        if heading:
+            fields.append(
+                NMEA2000Field(
+                    id="heading",
+                    name="Heading",
+                    value=heading.value * 3.14159265359 / 180.0,
+                    unit_of_measurement="rad",
+                )
+            )
+
+    rot_sample = skarv.get("yaw_rate_degps")
+    if rot_sample:
+        rot = unpack(rot_sample)
+        if rot:
+            fields.append(
+                NMEA2000Field(
+                    id="rateOfTurn",
+                    name="Rate of Turn",
+                    value=rot.value * 3.14159265359 / 180.0,
+                    unit_of_measurement="rad/s",
+                )
+            )
+
+    # navStatus carries the raw AIS code. keelson VesselNavStatus is the AIS
+    # code + 1 (0 = UNKNOWN); an absent or unknown status maps to AIS 15
+    # ("undefined"), not the LOOKUP filler's 0 ("under way using engine").
+    ais_nav_status = 15
+    nav_sample = skarv.get("nav_status")
+    if nav_sample:
+        nav = unpack(nav_sample)
+        if nav and nav.navigation_status >= 1:
+            ais_nav_status = nav.navigation_status - 1
+    fields.append(
+        NMEA2000Field(id="navStatus", name="Nav Status", raw_value=ais_nav_status)
+    )
+
+    emit(
+        build_nmea2000_message(
+            129038, "aisClassAPositionReport", "AIS Class A Position Report", fields
+        )
+    )
+
+
+def generate_pgn_129794():
+    """
+    Generate PGN 129794: AIS Class A Static and Voyage Related Data
+    Emitted periodically (--ais-static-period) in the ownship-ais / ais-target
+    modes.
+    """
+    mmsi_sample = skarv.get("mmsi_number")
+    if not mmsi_sample:
+        logger.warning("No mmsi_number available; skipping PGN 129794")
+        return
+    mmsi = unpack(mmsi_sample)
+    if not mmsi:
+        return
+
+    fields = [
+        NMEA2000Field(id="messageId", name="Message ID", raw_value=5),
+        NMEA2000Field(id="userId", name="User ID", value=mmsi.value),
+    ]
+
+    imo_sample = skarv.get("imo_number")
+    if imo_sample:
+        imo = unpack(imo_sample)
+        if imo:
+            fields.append(
+                NMEA2000Field(id="imoNumber", name="IMO number", value=imo.value)
+            )
+
+    name_sample = skarv.get("name")
+    if name_sample:
+        name = unpack(name_sample)
+        if name:
+            fields.append(NMEA2000Field(id="name", name="Name", value=name.value))
+
+    call_sign_sample = skarv.get("call_sign")
+    if call_sign_sample:
+        call_sign = unpack(call_sign_sample)
+        if call_sign:
+            fields.append(
+                NMEA2000Field(id="callsign", name="Callsign", value=call_sign.value)
+            )
+
+    destination_sample = skarv.get("destination")
+    if destination_sample:
+        destination = unpack(destination_sample)
+        if destination:
+            fields.append(
+                NMEA2000Field(
+                    id="destination", name="Destination", value=destination.value
+                )
+            )
+
+    vessel_type_sample = skarv.get("vessel_type")
+    if vessel_type_sample:
+        vessel_type = unpack(vessel_type_sample)
+        if vessel_type:
+            fields.append(
+                NMEA2000Field(
+                    id="typeOfShip",
+                    name="Type of ship",
+                    raw_value=vessel_type.vessel_type,
+                )
+            )
+
+    length = None
+    length_sample = skarv.get("length_over_all_m")
+    if length_sample:
+        length_msg = unpack(length_sample)
+        if length_msg:
+            length = length_msg.value
+            fields.append(
+                NMEA2000Field(
+                    id="length", name="Length", value=length, unit_of_measurement="m"
+                )
+            )
+
+    beam = None
+    beam_sample = skarv.get("breadth_over_all_m")
+    if beam_sample:
+        beam_msg = unpack(beam_sample)
+        if beam_msg:
+            beam = beam_msg.value
+            fields.append(
+                NMEA2000Field(
+                    id="beam", name="Beam", value=beam, unit_of_measurement="m"
+                )
+            )
+
+    draught_sample = skarv.get("draught_mean_m")
+    if draught_sample:
+        draught = unpack(draught_sample)
+        if draught:
+            fields.append(
+                NMEA2000Field(
+                    id="draft",
+                    name="Draft",
+                    value=draught.value,
+                    unit_of_measurement="m",
+                )
+            )
+
+    # Place the position reference at the geometric centre — the antenna
+    # assumption keelson2ais also makes for AIS message 5.
+    if length is not None:
+        fields.append(
+            NMEA2000Field(
+                id="positionReferenceFromBow",
+                name="Position reference from Bow",
+                value=length / 2.0,
+                unit_of_measurement="m",
+            )
+        )
+    if beam is not None:
+        fields.append(
+            NMEA2000Field(
+                id="positionReferenceFromStarboard",
+                name="Position reference from Starboard",
+                value=beam / 2.0,
+                unit_of_measurement="m",
+            )
+        )
+
+    eta_sample = skarv.get("eta")
+    if eta_sample:
+        eta = unpack(eta_sample)
+        if eta:
+            eta_dt = eta.value.ToDatetime()
+            fields.append(
+                NMEA2000Field(
+                    id="etaDate",
+                    name="ETA Date",
+                    value=eta_dt.date(),
+                    unit_of_measurement="d",
+                )
+            )
+            fields.append(
+                NMEA2000Field(
+                    id="etaTime",
+                    name="ETA Time",
+                    value=eta_dt.time(),
+                    unit_of_measurement="s",
+                )
+            )
+
+    emit(
+        build_nmea2000_message(
+            129794,
+            "aisClassAStaticAndVoyageData",
+            "AIS Class A Static and Voyage Related Data",
+            fields,
+        )
+    )
+
+
 def _await_gateway(runner, shutdown) -> bool:
     """Block until the gateway identity probe completes.
 
@@ -724,6 +1080,26 @@ def main():
         help="NMEA2000 message priority (0-7, lower is higher priority)",
     )
 
+    # NMEA 2000 output mode.
+    output_group = parser.add_argument_group("NMEA 2000 output")
+    output_group.add_argument(
+        "--inject-as",
+        choices=["ownship", "ownship-ais", "ais-target"],
+        default="ownship",
+        help="What to inject for the vessel read off the bus: 'ownship' = the "
+        "8 general instrument PGNs (default); 'ownship-ais' = those plus the "
+        "vessel's own AIS report (PGN 129038 + 129794); 'ais-target' = only "
+        "the AIS report, so the vessel appears as an AIS contact and no "
+        "general PGNs are injected.",
+    )
+    output_group.add_argument(
+        "--ais-static-period",
+        type=float,
+        default=300.0,
+        help="Seconds between PGN 129794 (AIS static & voyage) emissions "
+        "(ownship-ais / ais-target modes).",
+    )
+
     # CAN gateway selection.
     gateway_group = parser.add_argument_group("CAN gateway")
     gateway_group.add_argument(
@@ -752,7 +1128,7 @@ def main():
     )
 
     # Per-subject source ID patterns (wildcard support)
-    for subject in SUBJECTS:
+    for subject in SUBJECTS + AIS_SUBJECTS:
         parser.add_argument(
             f"--source_id_{subject}",
             type=str,
@@ -799,8 +1175,12 @@ def main():
             if not _await_gateway(RUNNER, shutdown):
                 return
 
-            # Mirror all subjects to skarv
-            for subject in SUBJECTS:
+            # Mirror subjects to skarv. The AIS modes additionally need the
+            # vessel-identity subjects.
+            subjects = list(SUBJECTS)
+            if ARGS.inject_as in ("ownship-ais", "ais-target"):
+                subjects += AIS_SUBJECTS
+            for subject in subjects:
                 source_id = getattr(ARGS, f"source_id_{subject}")
                 zenoh_key = keelson.construct_pubsub_key(
                     ARGS.realm, ARGS.entity_id, subject, source_id
@@ -808,7 +1188,18 @@ def main():
                 mirror(session, zenoh_key, subject)
                 logger.info(f"Subscribed to: {zenoh_key}")
 
-            logger.info("Injecting NMEA2000 into the CAN gateway...")
+            # PGN 129794 (AIS static & voyage) is re-sent on a timer rather
+            # than on subject updates.
+            if ARGS.inject_as in ("ownship-ais", "ais-target"):
+                skarv.utilities.call_every(ARGS.ais_static_period, wait_first=False)(
+                    generate_pgn_129794
+                )
+                logger.info("Emitting PGN 129794 every %.0fs", ARGS.ais_static_period)
+
+            logger.info(
+                "Injecting NMEA2000 into the CAN gateway (mode: %s)...",
+                ARGS.inject_as,
+            )
 
             # Keep running until interrupted
             while not shutdown.is_requested():

--- a/connectors/nmea/bin/n2k2keelson.py
+++ b/connectors/nmea/bin/n2k2keelson.py
@@ -15,6 +15,9 @@ Supported PGNs:
 - 130306: Wind Data
 - 127245: Rudder
 - 130311: Environmental Parameters
+- 129038: AIS Class A Position Report
+- 129039: AIS Class B Position Report
+- 129794: AIS Class A Static and Voyage Related Data
 """
 
 import sys
@@ -41,8 +44,11 @@ from keelson.helpers import (
     enclose_from_integer,
     enclose_from_lon_lat,
     enclose_from_string,
+    enclose_from_timestamp,
 )
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+from keelson.payloads.VesselNavStatus_pb2 import VesselNavStatus
+from keelson.payloads.VesselType_pb2 import VesselType as VesselTypePb
 
 # Sibling module in this bin/ directory.
 import n2k_gateway
@@ -131,16 +137,25 @@ N2K_INTEGRITY_NAME_TO_CODE: Dict[str, int] = {
 
 
 def get_or_create_publisher(
-    session, realm: str, entity_id: str, subject: str, source_id: str
+    session,
+    realm: str,
+    entity_id: str,
+    subject: str,
+    source_id: str,
+    target_id: str = None,
 ):
     """
     Get or create a Zenoh publisher for the specified subject.
 
     Publishers are cached globally to avoid recreating them for each message.
+    A ``target_id`` adds the ``@target`` key extension, used to scope a subject
+    to one observed vessel (e.g. an AIS contact keyed by MMSI).
     """
-    key = (realm, entity_id, subject, source_id)
+    key = (realm, entity_id, subject, source_id, target_id)
     if key not in PUBLISHERS:
-        key_expr = keelson.construct_pubsub_key(realm, entity_id, subject, source_id)
+        key_expr = keelson.construct_pubsub_key(
+            realm, entity_id, subject, source_id, target_id=target_id
+        )
         PUBLISHERS[key] = session.declare_publisher(key_expr)
         logger.info(f"Created publisher for {key_expr}")
     return PUBLISHERS[key]
@@ -153,9 +168,12 @@ def publish_to_keelson(
     subject: str,
     source_id: str,
     value: bytes,
+    target_id: str = None,
 ):
-    """Publish a value to a Keelson subject."""
-    publisher = get_or_create_publisher(session, realm, entity_id, subject, source_id)
+    """Publish a value to a Keelson subject, optionally scoped to a target."""
+    publisher = get_or_create_publisher(
+        session, realm, entity_id, subject, source_id, target_id
+    )
     publisher.put(value)
     logger.debug(f"Published to {subject}")
 
@@ -586,6 +604,304 @@ def handle_pgn_130311(
         logger.error(f"Error handling PGN 130311: {e}")
 
 
+# --- AIS PGN decode helpers ---------------------------------------------
+
+_RAD_TO_DEG = 180.0 / 3.14159265359
+
+
+def _field_degrees(field):
+    """Angle / angular-rate field value in degrees (the decoder yields radians)."""
+    value = field.value
+    if value is not None and field.unit_of_measurement in ("rad", "rad/s"):
+        value = value * _RAD_TO_DEG
+    return value
+
+
+def _field_knots(field):
+    """Speed field value in knots (the decoder yields m/s)."""
+    value = field.value
+    if value is not None and field.unit_of_measurement == "m/s":
+        value = value * 1.94384
+    return value
+
+
+def _enclose_nav_status(ais_status: int, timestamp: int) -> bytes:
+    """Enclose an AIS navigation-status code as a VesselNavStatus payload.
+
+    The keelson VesselNavStatus enum is the AIS code + 1 (0 is reserved for
+    UNKNOWN); see VesselNavStatus.proto.
+    """
+    payload = VesselNavStatus()
+    payload.timestamp.FromNanoseconds(timestamp or time.time_ns())
+    payload.navigation_status = ais_status + 1
+    return keelson.enclose(payload.SerializeToString())
+
+
+def _enclose_vessel_type(ais_ship_type: int, timestamp: int) -> bytes:
+    """Enclose an AIS ship-type code as a VesselType payload.
+
+    The keelson VesselType enum values are the AIS ship-type codes directly.
+    """
+    payload = VesselTypePb()
+    payload.timestamp.FromNanoseconds(timestamp or time.time_ns())
+    payload.vessel_type = ais_ship_type
+    return keelson.enclose(payload.SerializeToString())
+
+
+def _ais_eta_ns(date_field, time_field):
+    """Combine PGN 129794 etaDate + etaTime fields into a UTC timestamp (ns).
+
+    Returns None if either part is unavailable or not a usable date/time.
+    """
+    if date_field is None or time_field is None:
+        return None
+    eta_date = date_field.value
+    eta_time = time_field.value
+    if eta_date is None or eta_time is None:
+        return None
+    try:
+        eta = datetime.combine(eta_date, eta_time, tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+    return int(eta.timestamp() * 1_000_000_000)
+
+
+def _publish_ais_position(fields, publish, timestamp):
+    """Publish the position subjects common to PGN 129038 and 129039.
+
+    ``fields`` is an ``{id: NMEA2000Field}`` map and ``publish`` is a
+    ``publish(subject, envelope)`` callable already bound to an AIS target.
+    """
+    latitude = fields.get("latitude")
+    longitude = fields.get("longitude")
+    if (
+        latitude is not None
+        and latitude.value is not None
+        and longitude is not None
+        and longitude.value is not None
+    ):
+        publish(
+            "location_fix",
+            enclose_from_lon_lat(longitude.value, latitude.value, timestamp),
+        )
+
+    cog = fields.get("cog")
+    if cog is not None and cog.value is not None:
+        publish(
+            "course_over_ground_deg",
+            enclose_from_float(_field_degrees(cog), timestamp),
+        )
+
+    sog = fields.get("sog")
+    if sog is not None and sog.value is not None:
+        publish(
+            "speed_over_ground_knots",
+            enclose_from_float(_field_knots(sog), timestamp),
+        )
+
+    heading = fields.get("heading")
+    if heading is not None and heading.value is not None:
+        publish(
+            "heading_true_north_deg",
+            enclose_from_float(_field_degrees(heading), timestamp),
+        )
+
+
+def handle_pgn_129038(
+    msg: NMEA2000Message, session, realm: str, entity_id: str, source_id: str
+):
+    """
+    Handle PGN 129038: AIS Class A Position Report
+
+    Fields: userId (MMSI), latitude, longitude, cog, sog, heading,
+            rateOfTurn, navStatus
+    Keelson subjects (per AIS target): location_fix, course_over_ground_deg,
+            speed_over_ground_knots, heading_true_north_deg, yaw_rate_degps,
+            nav_status, mmsi_number
+    """
+    try:
+        fields = {field.id: field for field in msg.fields}
+
+        user_id = fields.get("userId")
+        mmsi = user_id.value if user_id is not None else None
+        if mmsi is None:
+            logger.debug("PGN 129038 without an MMSI; skipping")
+            return
+
+        timestamp = get_timestamp_ns(msg.timestamp)
+        target_id = f"mmsi_{mmsi}"
+
+        def publish(subject, envelope):
+            publish_to_keelson(
+                session,
+                realm,
+                entity_id,
+                subject,
+                source_id,
+                envelope,
+                target_id=target_id,
+            )
+
+        publish("mmsi_number", enclose_from_integer(int(mmsi), timestamp))
+        _publish_ais_position(fields, publish, timestamp)
+
+        rate_of_turn = fields.get("rateOfTurn")
+        if rate_of_turn is not None and rate_of_turn.value is not None:
+            publish(
+                "yaw_rate_degps",
+                enclose_from_float(_field_degrees(rate_of_turn), timestamp),
+            )
+
+        nav_status = fields.get("navStatus")
+        if nav_status is not None and nav_status.raw_value is not None:
+            publish(
+                "nav_status",
+                _enclose_nav_status(int(nav_status.raw_value), timestamp),
+            )
+
+        logger.debug(f"Published AIS Class A position for {target_id}")
+
+    except Exception as e:
+        logger.error(f"Error handling PGN 129038: {e}")
+
+
+def handle_pgn_129039(
+    msg: NMEA2000Message, session, realm: str, entity_id: str, source_id: str
+):
+    """
+    Handle PGN 129039: AIS Class B Position Report
+
+    Like PGN 129038, but the Class B report carries neither navigation
+    status nor rate of turn.
+
+    Keelson subjects (per AIS target): location_fix, course_over_ground_deg,
+            speed_over_ground_knots, heading_true_north_deg, mmsi_number
+    """
+    try:
+        fields = {field.id: field for field in msg.fields}
+
+        user_id = fields.get("userId")
+        mmsi = user_id.value if user_id is not None else None
+        if mmsi is None:
+            logger.debug("PGN 129039 without an MMSI; skipping")
+            return
+
+        timestamp = get_timestamp_ns(msg.timestamp)
+        target_id = f"mmsi_{mmsi}"
+
+        def publish(subject, envelope):
+            publish_to_keelson(
+                session,
+                realm,
+                entity_id,
+                subject,
+                source_id,
+                envelope,
+                target_id=target_id,
+            )
+
+        publish("mmsi_number", enclose_from_integer(int(mmsi), timestamp))
+        _publish_ais_position(fields, publish, timestamp)
+
+        logger.debug(f"Published AIS Class B position for {target_id}")
+
+    except Exception as e:
+        logger.error(f"Error handling PGN 129039: {e}")
+
+
+def handle_pgn_129794(
+    msg: NMEA2000Message, session, realm: str, entity_id: str, source_id: str
+):
+    """
+    Handle PGN 129794: AIS Class A Static and Voyage Related Data
+
+    Fields: userId (MMSI), name, callsign, imoNumber, typeOfShip, length,
+            beam, draft, etaDate, etaTime, destination
+    Keelson subjects (per AIS target): name, call_sign, imo_number,
+            vessel_type, length_over_all_m, breadth_over_all_m,
+            draught_mean_m, eta, destination, mmsi_number
+    """
+    try:
+        fields = {field.id: field for field in msg.fields}
+
+        user_id = fields.get("userId")
+        mmsi = user_id.value if user_id is not None else None
+        if mmsi is None:
+            logger.debug("PGN 129794 without an MMSI; skipping")
+            return
+
+        timestamp = get_timestamp_ns(msg.timestamp)
+        target_id = f"mmsi_{mmsi}"
+
+        def publish(subject, envelope):
+            publish_to_keelson(
+                session,
+                realm,
+                entity_id,
+                subject,
+                source_id,
+                envelope,
+                target_id=target_id,
+            )
+
+        publish("mmsi_number", enclose_from_integer(int(mmsi), timestamp))
+
+        name = fields.get("name")
+        if name is not None and name.value is not None:
+            publish("name", enclose_from_string(str(name.value), timestamp))
+
+        callsign = fields.get("callsign")
+        if callsign is not None and callsign.value is not None:
+            publish("call_sign", enclose_from_string(str(callsign.value), timestamp))
+
+        destination = fields.get("destination")
+        if destination is not None and destination.value is not None:
+            publish(
+                "destination",
+                enclose_from_string(str(destination.value), timestamp),
+            )
+
+        imo_number = fields.get("imoNumber")
+        if imo_number is not None and imo_number.value is not None:
+            publish(
+                "imo_number", enclose_from_integer(int(imo_number.value), timestamp)
+            )
+
+        type_of_ship = fields.get("typeOfShip")
+        if type_of_ship is not None and type_of_ship.raw_value is not None:
+            publish(
+                "vessel_type",
+                _enclose_vessel_type(int(type_of_ship.raw_value), timestamp),
+            )
+
+        length = fields.get("length")
+        if length is not None and length.value is not None:
+            publish(
+                "length_over_all_m",
+                enclose_from_float(float(length.value), timestamp),
+            )
+
+        beam = fields.get("beam")
+        if beam is not None and beam.value is not None:
+            publish(
+                "breadth_over_all_m",
+                enclose_from_float(float(beam.value), timestamp),
+            )
+
+        draft = fields.get("draft")
+        if draft is not None and draft.value is not None:
+            publish("draught_mean_m", enclose_from_float(float(draft.value), timestamp))
+
+        eta_ns = _ais_eta_ns(fields.get("etaDate"), fields.get("etaTime"))
+        if eta_ns is not None:
+            publish("eta", enclose_from_timestamp(eta_ns, timestamp))
+
+        logger.debug(f"Published AIS Class A static data for {target_id}")
+
+    except Exception as e:
+        logger.error(f"Error handling PGN 129794: {e}")
+
+
 # PGN Handler Registry
 PGN_HANDLERS: Dict[int, Callable] = {
     129025: handle_pgn_129025,  # Position, Rapid Update
@@ -596,6 +912,9 @@ PGN_HANDLERS: Dict[int, Callable] = {
     130306: handle_pgn_130306,  # Wind Data
     127245: handle_pgn_127245,  # Rudder
     130311: handle_pgn_130311,  # Environmental Parameters
+    129038: handle_pgn_129038,  # AIS Class A Position Report
+    129039: handle_pgn_129039,  # AIS Class B Position Report
+    129794: handle_pgn_129794,  # AIS Class A Static and Voyage Related Data
 }
 
 

--- a/connectors/nmea/tests/test_keelson2n2k_generators.py
+++ b/connectors/nmea/tests/test_keelson2n2k_generators.py
@@ -17,9 +17,17 @@ import pytest
 
 import skarv
 import keelson
-from keelson.payloads.Primitives_pb2 import TimestampedFloat, TimestampedInt
+from keelson.payloads.Primitives_pb2 import (
+    TimestampedFloat,
+    TimestampedInt,
+    TimestampedString,
+    TimestampedTimestamp,
+)
 from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+from keelson.payloads.VesselNavStatus_pb2 import VesselNavStatus
+from keelson.payloads.VesselType_pb2 import VesselType as VesselTypePb
+from nmea2000.decoder import NMEA2000Decoder
 from nmea2000.encoder import NMEA2000Encoder
 from nmea2000.input_formats import N2KFormat
 
@@ -55,6 +63,7 @@ def setup_args():
     keelson2n2k.ARGS = Mock()
     keelson2n2k.ARGS.source_address = 1
     keelson2n2k.ARGS.priority = 2
+    keelson2n2k.ARGS.inject_as = "ownship-ais"
     keelson2n2k.RUNNER = Mock()
     yield
     keelson2n2k.ARGS = None
@@ -95,6 +104,46 @@ def _put_int(subject: str, value: int):
     )
 
 
+def _put_string(subject: str, value: str):
+    """Publish a TimestampedString sample onto a skarv subject."""
+    payload = TimestampedString()
+    payload.timestamp.FromNanoseconds(_ts_now())
+    payload.value = value
+    skarv.put(
+        subject, create_zenoh_payload(keelson.enclose(payload.SerializeToString()))
+    )
+
+
+def _put_nav_status(subject: str, value: int):
+    """Publish a VesselNavStatus sample onto a skarv subject."""
+    payload = VesselNavStatus()
+    payload.timestamp.FromNanoseconds(_ts_now())
+    payload.navigation_status = value
+    skarv.put(
+        subject, create_zenoh_payload(keelson.enclose(payload.SerializeToString()))
+    )
+
+
+def _put_vessel_type(subject: str, value: int):
+    """Publish a VesselType sample onto a skarv subject."""
+    payload = VesselTypePb()
+    payload.timestamp.FromNanoseconds(_ts_now())
+    payload.vessel_type = value
+    skarv.put(
+        subject, create_zenoh_payload(keelson.enclose(payload.SerializeToString()))
+    )
+
+
+def _put_eta(subject: str, eta_ns: int):
+    """Publish a TimestampedTimestamp sample onto a skarv subject."""
+    payload = TimestampedTimestamp()
+    payload.timestamp.FromNanoseconds(_ts_now())
+    payload.value.FromNanoseconds(eta_ns)
+    skarv.put(
+        subject, create_zenoh_payload(keelson.enclose(payload.SerializeToString()))
+    )
+
+
 def _populate_all_subjects():
     """Publish one sample for every subject the PGN generators consume."""
     location = LocationFix()
@@ -119,6 +168,25 @@ def _populate_all_subjects():
     _put_float("rudder_angle_deg", 12.34)
     _put_float("water_temperature_celsius", 41.5)
     _put_float("air_pressure_pa", 99100.0)
+    _put_float("yaw_rate_degps", 1.5)
+    # AIS subjects (ownship-ais / ais-target modes).
+    _put_int("mmsi_number", 265547250)
+    _put_int("imo_number", 9811000)
+    _put_string("name", "KEELSON TEST")
+    _put_string("call_sign", "SHIP1")
+    _put_string("destination", "GOTHENBURG")
+    _put_nav_status("nav_status", 1)
+    _put_vessel_type("vessel_type", 70)
+    _put_float("length_over_all_m", 120.0)
+    _put_float("breadth_over_all_m", 20.0)
+    _put_float("draught_mean_m", 6.5)
+    _put_eta(
+        "eta",
+        int(
+            datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc).timestamp()
+            * 1_000_000_000
+        ),
+    )
 
 
 # ==================== SUBJECTS list ====================
@@ -407,6 +475,8 @@ def test_all_generated_pgns_encode(setup_args):
         keelson2n2k.generate_pgn_130306,
         keelson2n2k.generate_pgn_127245,
         keelson2n2k.generate_pgn_130311,
+        keelson2n2k.generate_pgn_129038,
+        keelson2n2k.generate_pgn_129794,
     ]
     failures = []
     for generator in generators:
@@ -446,3 +516,139 @@ def test_pgn_129029_satellite_count_uses_numberOfSvs(setup_args):
     assert "numberOfSvs" in fields
     assert "numberOfSatellites" not in fields
     assert fields["numberOfSvs"].value == 11
+
+
+# ==================== AIS PGN generators ====================
+
+
+def _put_location(lat: float, lon: float):
+    location = LocationFix()
+    location.timestamp.FromNanoseconds(_ts_now())
+    location.latitude = lat
+    location.longitude = lon
+    skarv.put(
+        "location_fix",
+        create_zenoh_payload(keelson.enclose(location.SerializeToString())),
+    )
+
+
+def test_generate_pgn_129038_position(setup_args):
+    """PGN 129038 carries the MMSI, position and motion of the vessel."""
+    _put_location(59.32, 18.07)
+    _put_int("mmsi_number", 265547250)
+    _put_float("course_over_ground_deg", 90.0)
+    _put_float("speed_over_ground_knots", 10.0)
+    _put_nav_status("nav_status", 2)  # keelson AT_ANCHOR -> AIS 1
+
+    msg = emitted_message(keelson2n2k.generate_pgn_129038)
+    assert msg is not None
+    assert msg.PGN == 129038
+    fields = fields_by_id(msg)
+    assert fields["messageId"].raw_value == 1
+    assert fields["userId"].value == 265547250
+    assert fields["latitude"].value == pytest.approx(59.32)
+    assert fields["longitude"].value == pytest.approx(18.07)
+    assert fields["cog"].value == pytest.approx(90.0 * 3.14159265359 / 180.0)
+    assert fields["navStatus"].raw_value == 1  # keelson 2 - 1
+
+
+def test_generate_pgn_129038_requires_mmsi(setup_args):
+    """Without mmsi_number, no PGN 129038 is emitted."""
+    _put_location(59.0, 18.0)
+    assert emitted_message(keelson2n2k.generate_pgn_129038) is None
+
+
+def test_generate_pgn_129038_nav_status_absent_is_undefined(setup_args):
+    """An absent nav_status encodes as AIS 15 ('undefined'), not 0."""
+    _put_location(59.0, 18.0)
+    _put_int("mmsi_number", 265547250)
+
+    msg = emitted_message(keelson2n2k.generate_pgn_129038)
+    assert msg is not None
+    assert fields_by_id(msg)["navStatus"].raw_value == 15
+
+
+def test_generate_pgn_129794_static(setup_args):
+    """PGN 129794 carries the vessel's static and voyage data."""
+    _put_int("mmsi_number", 265547250)
+    _put_int("imo_number", 9811000)
+    _put_string("name", "KEELSON TEST")
+    _put_string("call_sign", "SHIP1")
+    _put_vessel_type("vessel_type", 70)
+    _put_float("length_over_all_m", 120.0)
+    _put_float("breadth_over_all_m", 20.0)
+    _put_float("draught_mean_m", 6.5)
+
+    msg = emitted_message(keelson2n2k.generate_pgn_129794)
+    assert msg is not None
+    assert msg.PGN == 129794
+    fields = fields_by_id(msg)
+    assert fields["messageId"].raw_value == 5
+    assert fields["userId"].value == 265547250
+    assert fields["name"].value == "KEELSON TEST"
+    assert fields["imoNumber"].value == 9811000
+    assert fields["draft"].value == pytest.approx(6.5)
+    # Antenna placed at the geometric centre.
+    assert fields["positionReferenceFromBow"].value == pytest.approx(60.0)
+    assert fields["positionReferenceFromStarboard"].value == pytest.approx(10.0)
+
+
+def test_generate_pgn_129794_requires_mmsi(setup_args):
+    """Without mmsi_number, no PGN 129794 is emitted."""
+    _put_string("name", "NO MMSI")
+    assert emitted_message(keelson2n2k.generate_pgn_129794) is None
+
+
+def test_generate_pgn_129794_vessel_type_passthrough(setup_args):
+    """keelson VesselType values are the AIS ship-type codes directly."""
+    _put_int("mmsi_number", 265547250)
+    _put_vessel_type("vessel_type", 70)
+    msg = emitted_message(keelson2n2k.generate_pgn_129794)
+    assert msg is not None
+    assert fields_by_id(msg)["typeOfShip"].raw_value == 70
+
+
+def test_inject_as_ownship_drops_ais(setup_args):
+    """In ownship mode the AIS generators emit nothing."""
+    keelson2n2k.ARGS.inject_as = "ownship"
+    _put_location(59.0, 18.0)
+    _put_int("mmsi_number", 265547250)
+    assert emitted_message(keelson2n2k.generate_pgn_129038) is None
+
+
+def test_inject_as_ais_target_drops_general(setup_args):
+    """In ais-target mode emit() drops the general instrument PGNs."""
+    keelson2n2k.ARGS.inject_as = "ais-target"
+    _put_location(59.0, 18.0)
+    assert emitted_message(keelson2n2k.generate_pgn_129025) is None
+
+
+def test_roundtrip_129038(setup_args):
+    """A generated PGN 129038 survives encode -> decode with MMSI + position."""
+    _put_location(59.32, 18.07)
+    _put_int("mmsi_number", 265547250)
+
+    msg = emitted_message(keelson2n2k.generate_pgn_129038)
+    assert msg is not None
+
+    parts = NMEA2000Encoder().encode(msg, output_format=N2KFormat.CAN_FRAME_ASCII)
+    blob = b"".join(
+        part if isinstance(part, (bytes, bytearray)) else part.encode()
+        for part in parts
+    )
+    decoder = NMEA2000Decoder()
+    decoded = None
+    for line in blob.decode("utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        result = decoder.decode(line)
+        if result is not None:
+            decoded = result
+
+    assert decoded is not None
+    assert decoded.PGN == 129038
+    fields = {field.id: field for field in decoded.fields}
+    assert fields["userId"].value == 265547250
+    assert fields["latitude"].value == pytest.approx(59.32, abs=1e-4)
+    assert fields["longitude"].value == pytest.approx(18.07, abs=1e-4)

--- a/connectors/nmea/tests/test_n2k2keelson_ais.py
+++ b/connectors/nmea/tests/test_n2k2keelson_ais.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+
+"""Tests for n2k2keelson AIS PGN decode handlers (129038, 129039, 129794)."""
+
+import importlib.util
+import pathlib
+import sys
+from datetime import date, datetime, time, timezone
+from importlib.machinery import SourceFileLoader
+from unittest.mock import Mock
+
+import pytest
+import keelson
+from keelson.payloads.Primitives_pb2 import (
+    TimestampedFloat,
+    TimestampedString,
+    TimestampedTimestamp,
+)
+from keelson.payloads.VesselNavStatus_pb2 import VesselNavStatus
+from keelson.payloads.VesselType_pb2 import VesselType as VesselTypePb
+from nmea2000.message import NMEA2000Field, NMEA2000Message
+
+# Load the bin script dynamically (it is a standalone executable, not a package).
+BIN_ROOT = pathlib.Path(__file__).resolve().parent.parent / "bin"
+sys.path.insert(0, str(BIN_ROOT))
+_loader = SourceFileLoader("n2k2keelson", str(BIN_ROOT / "n2k2keelson.py"))
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+n2k2keelson = importlib.util.module_from_spec(_spec)
+_loader.exec_module(n2k2keelson)
+
+
+REALM = "test/realm"
+ENTITY = "sensors"
+SOURCE = "n2k/recv"
+MMSI = 265547250  # a neutral Swedish MMSI
+
+
+@pytest.fixture
+def recording_session():
+    """Mock Zenoh session recording published payloads keyed by key expression."""
+    n2k2keelson.PUBLISHERS.clear()
+    published: dict[str, list[bytes]] = {}
+
+    def declare_publisher(key_expr):
+        published.setdefault(key_expr, [])
+        pub = Mock()
+        pub.put = Mock(side_effect=lambda data: published[key_expr].append(data))
+        return pub
+
+    session = Mock()
+    session.declare_publisher = Mock(side_effect=declare_publisher)
+    session.published = published
+    return session
+
+
+def _field(field_id, value=None, raw_value=None, unit=None):
+    return NMEA2000Field(
+        id=field_id, value=value, raw_value=raw_value, unit_of_measurement=unit
+    )
+
+
+def _message(pgn, fields):
+    msg = NMEA2000Message(PGN=pgn, id=f"pgn{pgn}", timestamp=datetime.now(timezone.utc))
+    msg.fields = fields
+    return msg
+
+
+def _key_for(session, subject):
+    """Return the (single) key expression whose subject segment matches."""
+    matches = [k for k in session.published if f"/pubsub/{subject}/" in k]
+    assert len(matches) <= 1, f"ambiguous keys for {subject}: {matches}"
+    return matches[0] if matches else None
+
+
+def _payload(session, subject):
+    """Return (key, decoded payload bytes) for a published subject."""
+    key = _key_for(session, subject)
+    assert key is not None, f"{subject} was not published"
+    payloads = session.published[key]
+    assert len(payloads) == 1
+    *_, raw = keelson.uncover(payloads[0])
+    return key, raw
+
+
+# --- PGN 129038: AIS Class A position ------------------------------------
+
+
+def _class_a_position():
+    return _message(
+        129038,
+        [
+            _field("userId", value=MMSI, raw_value=MMSI),
+            _field("latitude", value=59.32, unit="deg"),
+            _field("longitude", value=18.07, unit="deg"),
+            _field("cog", value=1.5707963, unit="rad"),
+            _field("sog", value=5.144, unit="m/s"),
+            _field("heading", value=0.7853982, unit="rad"),
+            _field("rateOfTurn", value=0.0, unit="rad/s"),
+            _field("navStatus", value="Under way using engine", raw_value=0),
+        ],
+    )
+
+
+def test_129038_publishes_all_subjects_with_target(recording_session):
+    n2k2keelson.handle_pgn_129038(
+        _class_a_position(), recording_session, REALM, ENTITY, SOURCE
+    )
+    for subject in (
+        "mmsi_number",
+        "location_fix",
+        "course_over_ground_deg",
+        "speed_over_ground_knots",
+        "heading_true_north_deg",
+        "yaw_rate_degps",
+        "nav_status",
+    ):
+        key = _key_for(recording_session, subject)
+        assert key is not None, f"{subject} not published"
+        assert key.endswith(f"/@target/mmsi_{MMSI}")
+
+
+def test_129038_unit_conversions(recording_session):
+    n2k2keelson.handle_pgn_129038(
+        _class_a_position(), recording_session, REALM, ENTITY, SOURCE
+    )
+
+    _, cog_raw = _payload(recording_session, "course_over_ground_deg")
+    cog = TimestampedFloat()
+    cog.ParseFromString(cog_raw)
+    assert cog.value == pytest.approx(90.0, abs=1e-3)
+
+    _, sog_raw = _payload(recording_session, "speed_over_ground_knots")
+    sog = TimestampedFloat()
+    sog.ParseFromString(sog_raw)
+    assert sog.value == pytest.approx(5.144 * 1.94384, abs=1e-3)
+
+
+def test_129038_nav_status_offset(recording_session):
+    """The keelson VesselNavStatus enum is the AIS code + 1."""
+    n2k2keelson.handle_pgn_129038(
+        _class_a_position(), recording_session, REALM, ENTITY, SOURCE
+    )
+    _, raw = _payload(recording_session, "nav_status")
+    nav = VesselNavStatus()
+    nav.ParseFromString(raw)
+    assert nav.navigation_status == 1  # AIS 0 -> keelson 1
+
+
+def test_129038_skips_not_available_fields(recording_session):
+    msg = _message(
+        129038,
+        [
+            _field("userId", value=MMSI, raw_value=MMSI),
+            _field("latitude", value=None, unit="deg"),
+            _field("longitude", value=None, unit="deg"),
+            _field("cog", value=None, unit="rad"),
+            _field("sog", value=None, unit="m/s"),
+            _field("heading", value=None, unit="rad"),
+            _field("rateOfTurn", value=None, unit="rad/s"),
+            _field("navStatus", value=None, raw_value=None),
+        ],
+    )
+    n2k2keelson.handle_pgn_129038(msg, recording_session, REALM, ENTITY, SOURCE)
+    # Only the MMSI is always available.
+    assert _key_for(recording_session, "mmsi_number") is not None
+    for subject in ("location_fix", "course_over_ground_deg", "nav_status"):
+        assert _key_for(recording_session, subject) is None
+
+
+def test_129038_without_mmsi_publishes_nothing(recording_session):
+    msg = _message(129038, [_field("userId", value=None, raw_value=None)])
+    n2k2keelson.handle_pgn_129038(msg, recording_session, REALM, ENTITY, SOURCE)
+    assert recording_session.published == {}
+
+
+# --- PGN 129039: AIS Class B position ------------------------------------
+
+
+def test_129039_publishes_position_without_nav_status(recording_session):
+    msg = _message(
+        129039,
+        [
+            _field("userId", value=MMSI, raw_value=MMSI),
+            _field("latitude", value=59.32, unit="deg"),
+            _field("longitude", value=18.07, unit="deg"),
+            _field("cog", value=1.5707963, unit="rad"),
+            _field("sog", value=5.144, unit="m/s"),
+            _field("heading", value=0.7853982, unit="rad"),
+        ],
+    )
+    n2k2keelson.handle_pgn_129039(msg, recording_session, REALM, ENTITY, SOURCE)
+
+    for subject in (
+        "mmsi_number",
+        "location_fix",
+        "course_over_ground_deg",
+        "speed_over_ground_knots",
+        "heading_true_north_deg",
+    ):
+        assert _key_for(recording_session, subject) is not None
+    # Class B carries neither navigation status nor rate of turn.
+    assert _key_for(recording_session, "nav_status") is None
+    assert _key_for(recording_session, "yaw_rate_degps") is None
+
+
+# --- PGN 129794: AIS Class A static --------------------------------------
+
+
+def _class_a_static():
+    return _message(
+        129794,
+        [
+            _field("userId", value=MMSI, raw_value=MMSI),
+            _field("name", value="KEELSON TEST"),
+            _field("callsign", value="SHIP1"),
+            _field("imoNumber", value=9811000),
+            _field("typeOfShip", value="Cargo", raw_value=70),
+            _field("length", value=120.0, unit="m"),
+            _field("beam", value=20.0, unit="m"),
+            _field("draft", value=6.5, unit="m"),
+            _field("etaDate", value=date(2026, 6, 1)),
+            _field("etaTime", value=time(13, 30)),
+            _field("destination", value="GOTHENBURG"),
+        ],
+    )
+
+
+def test_129794_publishes_static_subjects(recording_session):
+    n2k2keelson.handle_pgn_129794(
+        _class_a_static(), recording_session, REALM, ENTITY, SOURCE
+    )
+    for subject in (
+        "mmsi_number",
+        "name",
+        "call_sign",
+        "imo_number",
+        "vessel_type",
+        "length_over_all_m",
+        "breadth_over_all_m",
+        "draught_mean_m",
+        "eta",
+        "destination",
+    ):
+        key = _key_for(recording_session, subject)
+        assert key is not None, f"{subject} not published"
+        assert key.endswith(f"/@target/mmsi_{MMSI}")
+
+
+def test_129794_vessel_type_passthrough(recording_session):
+    """The keelson VesselType values are the AIS ship-type codes directly."""
+    n2k2keelson.handle_pgn_129794(
+        _class_a_static(), recording_session, REALM, ENTITY, SOURCE
+    )
+    _, raw = _payload(recording_session, "vessel_type")
+    vessel_type = VesselTypePb()
+    vessel_type.ParseFromString(raw)
+    assert vessel_type.vessel_type == 70
+
+
+def test_129794_eta_reconstructed(recording_session):
+    n2k2keelson.handle_pgn_129794(
+        _class_a_static(), recording_session, REALM, ENTITY, SOURCE
+    )
+    _, raw = _payload(recording_session, "eta")
+    eta = TimestampedTimestamp()
+    eta.ParseFromString(raw)
+    expected_ns = int(
+        datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc).timestamp() * 1_000_000_000
+    )
+    assert eta.value.ToNanoseconds() == expected_ns
+
+
+def test_129794_name_value(recording_session):
+    n2k2keelson.handle_pgn_129794(
+        _class_a_static(), recording_session, REALM, ENTITY, SOURCE
+    )
+    _, raw = _payload(recording_session, "name")
+    name = TimestampedString()
+    name.ParseFromString(raw)
+    assert name.value == "KEELSON TEST"
+
+
+# --- target_id format + regression ---------------------------------------
+
+
+def test_target_id_format_is_mmsi_prefixed(recording_session):
+    """The target_id shared with the ais connector is 'mmsi_<MMSI>'."""
+    n2k2keelson.handle_pgn_129038(
+        _class_a_position(), recording_session, REALM, ENTITY, SOURCE
+    )
+    key = _key_for(recording_session, "location_fix")
+    assert "/@target/mmsi_265547250" in key
+
+
+def test_non_ais_handler_publishes_without_target(recording_session):
+    """Existing non-AIS handlers must still publish with no @target segment."""
+    msg = _message(
+        129025,
+        [
+            _field("latitude", value=59.32, unit="deg"),
+            _field("longitude", value=18.07, unit="deg"),
+        ],
+    )
+    n2k2keelson.handle_pgn_129025(msg, recording_session, REALM, ENTITY, SOURCE)
+    key = _key_for(recording_session, "location_fix")
+    assert key is not None
+    assert "@target" not in key
+
+
+def test_ais_pgns_registered():
+    for pgn in (129038, 129039, 129794):
+        assert pgn in n2k2keelson.PGN_HANDLERS


### PR DESCRIPTION
  ## Summary

  Adds bidirectional NMEA 2000 AIS support to the `nmea` connector — `n2k2keelson` decodes AIS reports from a CAN gateway, and `keelson2n2k` injects them onto one.

  Self-contained in the `nmea` connector: no SDK, proto, `subjects.yaml`, or regeneration touched. Every subject the new generators read already exists; the AIS PGN
   codec is the `nmea2000` library (already a dependency).

  ## `n2k2keelson` — multi-target AIS decode

  Adds handlers for three inbound AIS PGNs:

  - **129038** — AIS Class A position report
  - **129039** — AIS Class B position report
  - **129794** — AIS Class A static & voyage data

  Each report is published as the existing scalar subjects (`location_fix`, `course_over_ground_deg`, `mmsi_number`, `name`, …) scoped per observed vessel with
  `target_id = "mmsi_<MMSI>"`. `get_or_create_publisher` / `publish_to_keelson` gain an optional `target_id` parameter; the eight existing handlers pass `None` and
  behave identically.

  ## `keelson2n2k` — own-ship AIS injection (`--inject-as`)

  `keelson2n2k` reads exactly one vessel off the bus. New `--inject-as` chooses how that vessel is rendered onto the N2K bus:

  | Mode | Injects | Use |
  |---|---|---|
  | `ownship` *(default)* | 8 general instrument PGNs | the vessel **is** the bus's own ship — today's behavior |
  | `ownship-ais` | general PGNs **+** 129038/129794 | own ship plus its AIS transponder broadcast |
  | `ais-target` | 129038/129794 **only** | the vessel appears as an AIS **contact**; no general PGNs |

  - 129038 fires on `location_fix`; 129794 (static & voyage) is re-sent every `--ais-static-period` seconds (default 300) via `skarv.utilities.call_every`.
  - `emit()` gates every PGN against the active mode — an `ais-target` run can never leak a 129025 even though `location_fix` still fires the existing position
  generator.
  - AIS PGNs require `mmsi_number`; absent → skipped with a warning, mirroring `keelson2ais`.
  - Field plumbing: `nav_status` carries the `VesselNavStatus −1` offset (absent → AIS 15 "undefined", not the LOOKUP filler's 0 "under way"); `vessel_type` passes
  through; `communicationState` (BINARY) is left to the `value=None` filler, which encodes to 0.

  ## Why own-ship / one-entity (not multi-target)

  `keelson2n2k` injects one entity. Many vessels = many connector instances. The `target_id`-wildcard multi-target design solves "bridge a received AIS feed", but
  the simulation use case is multi-*entity* — each simulated vessel is its own keelson entity, not a `target_id` under one entity. `n2k2keelson` is multi-target
  because that direction inherently sees many vessels.

  ## Out of scope (deferred backlog)

  - **Class B injection** — would need 129039 plus the 129809/810 static pair as a coherent unit. `n2k2keelson` already decodes 129039.
  - **`ais2keelson` / `digitraffic2keelson` codec dedup** — sentinels, the `nav_status +1` offset, and antenna translation are still copy-pasted; not touched here.
  - **`ais2keelson` Class A/B preservation** — flattening msg 1/2/3 (Class A) and msg 18 (Class B) into the same subjects loses transponder class. No
  `TransponderClass` proto introduced, since nothing in scope consumes it.

  ## Known limitation

  `ais-target` emits Class A only, so every injected target renders as Class A on the plotter — a direct consequence of Class B being out of scope.

  ## Tests

  - `keelson2n2k` generator tests (incl. AIS + encode→decode roundtrip): **27 passed**
  - `n2k2keelson` AIS decode tests: **13 passed**
  - nmea connector unit tests (regression): **173 passed**
  - nmea connector e2e tests: **6 passed**
  - ruff / black: clean

  The "encode every generated PGN" guard now covers 129038 + 129794, so `PGN_REQUIRED_FIELDS` is protected against `nmea2000` library drift.