### PR TITLE
docs: dual-pattern @target subscriptions in recorder examples + ratio…

### DIFF
--- a/connectors/klog/README.md
+++ b/connectors/klog/README.md
@@ -33,11 +33,18 @@ options:
 # Show help
 docker run --rm ghcr.io/rise-maritime/keelson "klog-record -h"
 
-# Record
+# Record.
+#
+# Two -k patterns are required to capture both own-entity messages and
+# observations of external entities published under the @target/ extension
+# (e.g. AIS-tracked vessels). A single pubsub/** pattern silently misses
+# every @target-extended key. See protocol spec §2.1.1.
 docker run --rm --network host \
   --volume /home/user/rec_klog:/rec_klog \
   ghcr.io/rise-maritime/keelson \
-  "klog-record --output /rec_klog/2024-05-15.klog -k rise/v0/my_vessel/pubsub/**"
+  "klog-record --output /rec_klog/2024-05-15.klog \
+               -k rise/v0/my_vessel/pubsub/** \
+               -k rise/v0/my_vessel/pubsub/**/@target/**"
 ```
 
 

--- a/connectors/mcap/README.md
+++ b/connectors/mcap/README.md
@@ -63,12 +63,18 @@ options:
 ### Example
 
 ```bash
-# Record all keys under a realm with hourly rotation
+# Record all keys under a realm with hourly rotation.
+#
+# Two -k patterns are required to capture both own-entity messages and
+# observations of external entities published under the @target/ extension
+# (e.g. AIS-tracked vessels). A single pubsub/** pattern silently misses
+# every @target-extended key. See protocol spec §2.1.1.
 uv run python connectors/mcap/bin/keelson2mcap.py \
   --output-folder ./recordings \
   --file-name "%Y-%m-%d_%H%M%S" \
   --rotate-when H \
-  -k "rise/v0/my_vessel/pubsub/**"
+  -k "rise/v0/my_vessel/pubsub/**" \
+  -k "rise/v0/my_vessel/pubsub/**/@target/**"
 ```
 
 ### Run in container
@@ -77,11 +83,13 @@ uv run python connectors/mcap/bin/keelson2mcap.py \
 # Show help
 docker run --rm ghcr.io/rise-maritime/keelson "keelson2mcap -h"
 
-# Record
+# Record (dual -k patterns required to also capture @target-extended keys; see above)
 docker run --rm --network host \
   --volume /home/user/rec_mcap:/rec_mcap \
   ghcr.io/rise-maritime/keelson \
-  "keelson2mcap --output-folder /rec_mcap -k rise/v0/my_vessel/pubsub/**"
+  "keelson2mcap --output-folder /rec_mcap \
+                -k rise/v0/my_vessel/pubsub/** \
+                -k rise/v0/my_vessel/pubsub/**/@target/**"
 ```
 
 ## MCAP Tagg

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -70,9 +70,18 @@ Further, the [`zenoh-cli`](https://pypi.org/project/zenoh-cli) (also written in 
         message = keelson.decode_protobuf_payload_from_type_name(payload, schema)
         print(f"Received on {key}: {message}")
 
-    # Subscribe using a wildcard key expression
-    sub = session.declare_subscriber(
+    # Subscribe using wildcard key expressions.
+    #
+    # Two subscriptions are needed to capture both own-entity messages and
+    # observations of external entities published under the @target/ extension
+    # (e.g. AIS-tracked vessels). The pubsub/** wildcard alone does not cross
+    # the verbatim @target chunk. See protocol specification §2.1.1.
+    sub_own = session.declare_subscriber(
         "my_realm/v0/my_vessel/pubsub/**",
+        on_sample,
+    )
+    sub_targets = session.declare_subscriber(
+        "my_realm/v0/my_vessel/pubsub/**/@target/**",
         on_sample,
     )
 

--- a/docs/protocol-specification.md
+++ b/docs/protocol-specification.md
@@ -93,6 +93,37 @@ Do NOT use `@target` when:
 * The data describes the entity itself (e.g., own-ship position from onboard GNSS)
 * The source_id sufficiently identifies the data origin
 
+##### Why `@target` is verbatim (and why no other extensions should be)
+
+The verbatim isolation is load-bearing for one specific property: a subscriber
+to `pubsub/{subject}/**` receives **only** self-observations, with no risk of
+silently mixing in observations of external entities published on the same
+subject. This matters for safety-critical consumers such as own-ship state
+estimators, which must not fuse AIS-tracked-vessel positions as if they were
+own-ship sensor readings.
+
+The cost of that isolation is **discoverability**: any "capture everything"
+consumer (recorders, replay tools, audit pipelines) cannot rely on a single
+`pubsub/**` subscription — it must explicitly include `pubsub/**/@target/**`
+alongside, per the dual-pattern idiom above. The mcap and klog connector
+examples in this repository demonstrate this idiom.
+
+This trade-off — wildcard isolation at the cost of discoverability — should
+**not** be replicated for other classes of context. The discoverability tax
+compounds with each new verbatim extension, and most context distinctions
+(producer role, setpoint vs. measurement, modality of observation, …) can be
+expressed via `source_id` without introducing a new verbatim chunk. A new
+verbatim extension should clear two bars:
+
+1. The isolation property prevents a safety-class bug (an accidental mixing
+   would cause a class-of-failure meaningfully worse than "annoying"), and
+2. The marker carries structured payload that benefits from key-pattern
+   matching (`@target/{target_id}` supports `@target/mmsi_*` subscriptions —
+   a property `source_id` encoding alone could not give cleanly).
+
+`@target` clears both bars. Future candidates should be evaluated against
+them rather than added by analogy.
+
 ### 2.2 Message format specification
 
 Each message published to zenoh must be a protobuf-encoded keelson `Envelope`. An `Envelope` contains exactly one (1) `payload`, we say that a `payload` is **enclosed** within an `Envelope` by the publisher and can later be **uncovered** from that `Envelope` by the subscriber. 


### PR DESCRIPTION
…nale

Every "record everything" / "subscribe to everything" example in the repo used a single pubsub/** pattern, which silently misses @target-extended keys because ** cannot cross the verbatim @target chunk. Recordings from mcap/klog following the README would have contained zero AIS-tracked vessel observations (tak, n2k AIS PGNs) even though those producers publish them. The bug was in the docs, not the recorder code.

- connectors/mcap/README.md, connectors/klog/README.md: recording examples now use dual -k patterns and inline comments pointing at protocol spec §2.1.1.
- docs/how-to-use.md: subscriber tutorial uses two declare_subscriber calls for the same reason.
- docs/protocol-specification.md §2.1.1: new "Why @target is verbatim (and why no other extensions should be)" subsection capturing the load-bearing isolation property, the discoverability cost it imposes, and a two-bar test for evaluating any future verbatim extension (safety-class isolation + structured marker payload).

Liveliness examples (docs/health-monitoring.md, spec §5.2) are deliberately unchanged: tokens use pubsub/*/{source_id} format and have no @target extension, so liveliness subscribers don't need the dual-pattern.