### PR TITLE
chore: bump setup-uv to v7 + devcontainer local Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm
+
+# Yarn rotated its Debian apt signing key, which breaks `apt-get update` and any
+# feature install that runs it (e.g. docker-in-docker). We use npm, not the yarn
+# apt repo, so drop the repo definition before features are layered on top.
+RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,9 @@
 {
 	"name": "Keelson Development",
-	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
-		"ghcr.io/devcontainers/features/python:1": {
-			"version": "3.13"
-		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "lts"

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -58,7 +58,7 @@ Triggers: GitHub release published.
 
 ## Key Details
 
-- **uv**: installed via `astral-sh/setup-uv@v4`
+- **uv**: installed via `astral-sh/setup-uv@v7`
 - **Node**: 20.x via `actions/setup-node@v4`
 - **Docker smoke tests**: run `--help` on every binary to verify they're accessible and parseable
 - **JS SDK**: needs both `uv sync --group dev` (for protoc) and `npm ci` (for ts-proto)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync workspace
         run: uv sync --group dev
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync workspace with all packages
         run: uv sync --all-packages --group dev
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync workspace with all packages
         run: uv sync --all-packages --group dev
@@ -114,7 +114,7 @@ jobs:
         with:
           node-version: '20.x'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync for protoc
         run: uv sync --group dev
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync for protoc
         run: uv sync --group dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Sync workspace
         run: uv sync --group dev
@@ -45,7 +45,7 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Update npm
         run: npm install -g npm@latest
@@ -79,7 +79,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
       -
         name: Sync for protoc
         run: uv sync --group dev
@@ -127,7 +127,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
 
       - name: Cache
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ tmp/
 
 # AI
 .claude
+.devcontainer/devcontainer-lock.json


### PR DESCRIPTION
## Summary

Two low-risk tooling changes, **PR 1 of the `5.1.0V-trial` split**:

- **`astral-sh/setup-uv@v4` → `@v7`** across all CI and release jobs (`ci.yml`, `release.yml`) and the matching note in `.github/CLAUDE.md`.
- **Devcontainer builds from a local Dockerfile** instead of the base image + python feature. The Dockerfile drops Yarn's stale Debian apt signing key (`/etc/apt/sources.list.d/yarn.list`), which otherwise breaks `apt-get update` during feature install (e.g. docker-in-docker). `.gitignore` now ignores the generated `.devcontainer/devcontainer-lock.json`.

No source, proto, or dependency-lock changes. Cherry-picked verbatim from the trial branch (commits c0586a9, 248843a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)