### PR TITLE
feat(interfaces): typed ErrorResponse.Code enum

### DIFF
--- a/interfaces/ErrorResponse.proto
+++ b/interfaces/ErrorResponse.proto
@@ -2,4 +2,20 @@ syntax = "proto3";
 
 message ErrorResponse {
   string error_description = 1;
+
+  // Typed code so clients can react without parsing the description.
+  // Producers SHOULD emit a specific code when applicable; UNSPECIFIED
+  // remains backwards-compatible for callers that don't yet care.
+  enum Code {
+    UNSPECIFIED = 0;
+    NOT_FOUND = 1;            // file or resource missing
+    INVALID_ARGUMENT = 2;     // malformed request payload
+    OUT_OF_RANGE = 3;         // seek beyond file, speed out of bounds, ...
+    INVALID_STATE = 4;        // wrong state for the operation (e.g. pause when STOPPED)
+    PERMISSION_DENIED = 5;    // path escapes base directory, lock-down rules
+    IO_FAILURE = 6;           // read/write fault on disk, network, etc.
+    UNAVAILABLE = 7;          // backend / dependency not ready
+    INTERNAL = 8;             // unhandled exception
+  }
+  Code code = 2;
 }


### PR DESCRIPTION
## Summary

Adds a typed `Code` enum to `ErrorResponse` so RPC clients can react to failures programmatically without parsing `error_description`. **PR 4 of the `5.1.0V-trial` split**, and a **prerequisite for the upcoming MCAP replay daemon PR**, which maps every RPC error to one of these codes.

- `UNSPECIFIED = 0` keeps existing producers/callers backward-compatible; producers SHOULD emit a specific code when applicable.
- Codes: `NOT_FOUND`, `INVALID_ARGUMENT`, `OUT_OF_RANGE`, `INVALID_STATE`, `PERMISSION_DENIED`, `IO_FAILURE`, `UNAVAILABLE`, `INTERNAL`.

## Validation
- Python and JS SDKs regenerate cleanly; the generated `ErrorResponse.Code` enum exposes all 9 values.
- `uv run pytest sdks/python/tests/` — 99 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)