### PR TITLE
fix(foxglove): drain queue on shutdown with bounded join

### DIFF
--- a/connectors/foxglove/bin/keelson2foxglove.py
+++ b/connectors/foxglove/bin/keelson2foxglove.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import time
 import pathlib
 import logging
 import argparse
@@ -89,7 +88,11 @@ def run(session: zenoh.Session, args: argparse.Namespace):
         def _ws_publisher():
             channels: Dict[str, Channel] = {}
 
-            while not shutdown.is_requested():
+            # Keep draining after shutdown is requested so the main thread's
+            # cleanup doesn't hang waiting for an empty queue we ourselves
+            # stopped consuming. Only exit when shutdown AND the queue is
+            # empty.
+            while not shutdown.is_requested() or not queue.empty():
                 with suppress_exception(Exception, context="ws publisher"):
                     try:
                         sample: zenoh.Sample = queue.get(timeout=0.01)
@@ -190,12 +193,13 @@ def run(session: zenoh.Session, args: argparse.Namespace):
         for sub in subscribers:
             sub.undeclare()
 
-        logger.debug("Waiting for all items in queue to be processed...")
-        while not queue.empty():
-            time.sleep(0.1)
-
+        # Publisher thread now drains the queue itself (see _ws_publisher),
+        # so we just wait for it to finish. Bounded join so a hung consumer
+        # (e.g. a Foxglove client holding up the server) can't trap shutdown.
         logger.debug("Joining websocket publisher thread...")
-        ws_publisher_thread.join()
+        ws_publisher_thread.join(timeout=5.0)
+        if ws_publisher_thread.is_alive():
+            logger.warning("ws publisher thread did not exit within 5s; abandoning")
 
         logger.debug("Stopping websocket server...")
         server.stop()


### PR DESCRIPTION
## Summary

Fixes a shutdown hang in the foxglove connector. **PR 2 of the `5.1.0V-trial` split.**

Previously the websocket-publisher thread stopped consuming the sample queue as soon as shutdown was requested, while the main thread's cleanup blocked **indefinitely** waiting for that same queue to drain — a deadlock on shutdown.

### Fix
- The publisher thread now keeps draining until shutdown is requested **and** the queue is empty (`while not shutdown.is_requested() or not queue.empty()`).
- The main thread joins it with a **5s bounded timeout** (logs a warning and abandons the thread if it overruns), so a hung Foxglove client holding up the server can no longer trap shutdown.

Single-file change to `connectors/foxglove/bin/keelson2foxglove.py`.

> Note: the trial branch's 3-dot diff also showed a `foxglove-sdk` 0.4→0.5 bump, but that already landed on `main` separately — so this PR is the drain fix only, with no dependency change.

## Validation
- `uv run pytest connectors/foxglove/` — 5 passed (CLI + e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)