### PR TITLE
feat(sdk): two-stage graceful-shutdown escalation

### DIFF
--- a/sdks/python/keelson/scaffolding/signals.py
+++ b/sdks/python/keelson/scaffolding/signals.py
@@ -57,13 +57,34 @@ class GracefulShutdown:
         self._custom_handlers = custom_handlers or {}
 
     def _handle_shutdown_signal(self, signum: int, frame) -> None:
-        """Signal handler that sets the shutdown flag."""
-        sig_name = signal.Signals(signum).name
-        logger.info("Received %s, initiating graceful shutdown...", sig_name)
-        self._shutdown_requested.set()
+        """Signal handler with two-stage escalation.
 
-        if self._on_shutdown:
-            self._on_shutdown()
+        First signal: set the shutdown flag so the main loop can run its
+        cooperative cleanup. A second signal restores the default
+        disposition and re-raises it, so the same signal terminates the
+        process immediately — an operator who sees cleanup taking too long
+        can force the exit with another Ctrl+C instead of ``kill -9``.
+
+        Limitation: Python runs signal handlers on the main thread at
+        bytecode boundaries and does not re-enter this handler for the same
+        signal, so the escalation can only break cleanup that is itself
+        interruptible (a pure-Python loop or a timed wait). It cannot
+        interrupt a hang inside ``on_shutdown`` or inside an
+        uninterruptible C call.
+        """
+        sig_name = signal.Signals(signum).name
+        if not self._shutdown_requested.is_set():
+            logger.info("Received %s, initiating graceful shutdown...", sig_name)
+            self._shutdown_requested.set()
+            if self._on_shutdown:
+                self._on_shutdown()
+            return
+
+        # Second (or later) signal: cleanup is still running. Restore the
+        # default disposition and re-raise so this signal terminates now.
+        logger.warning("Received %s again while shutting down; forcing exit.", sig_name)
+        signal.signal(signum, signal.SIG_DFL)
+        signal.raise_signal(signum)
 
     def _make_custom_handler(self, callback: Callable[[], None]) -> Callable:
         """Create a signal handler that calls the custom callback."""

--- a/sdks/python/tests/test_scaffolding_signals.py
+++ b/sdks/python/tests/test_scaffolding_signals.py
@@ -3,6 +3,7 @@
 import signal
 import threading
 import time
+from unittest import mock
 
 
 from keelson.scaffolding import GracefulShutdown
@@ -69,6 +70,59 @@ class TestGracefulShutdown:
 
             assert len(callback_called) == 1
             assert shutdown.is_requested()
+
+    def test_first_signal_does_not_escalate(self):
+        """First signal requests shutdown without touching disposition."""
+        with GracefulShutdown(signals=[signal.SIGINT]) as shutdown:
+            with (
+                mock.patch("keelson.scaffolding.signals.signal.signal") as mock_signal,
+                mock.patch(
+                    "keelson.scaffolding.signals.signal.raise_signal"
+                ) as mock_raise,
+            ):
+                shutdown._handle_shutdown_signal(signal.SIGINT, None)
+
+                assert shutdown.is_requested()
+                # No escalation on the first signal.
+                mock_signal.assert_not_called()
+                mock_raise.assert_not_called()
+
+    def test_second_signal_restores_default_and_reraises(self):
+        """A second signal forces exit by re-raising under SIG_DFL."""
+        with GracefulShutdown(signals=[signal.SIGINT]) as shutdown:
+            shutdown.request()  # shutdown already in progress
+
+            with (
+                mock.patch("keelson.scaffolding.signals.signal.signal") as mock_signal,
+                mock.patch(
+                    "keelson.scaffolding.signals.signal.raise_signal"
+                ) as mock_raise,
+            ):
+                shutdown._handle_shutdown_signal(signal.SIGINT, None)
+
+                # Default disposition restored, then the signal re-raised so
+                # it terminates the process immediately (double-press force).
+                mock_signal.assert_called_once_with(signal.SIGINT, signal.SIG_DFL)
+                mock_raise.assert_called_once_with(signal.SIGINT)
+
+    def test_second_signal_does_not_recall_on_shutdown(self):
+        """The escalation path must not re-run the on_shutdown callback."""
+        calls = []
+
+        with GracefulShutdown(
+            signals=[signal.SIGINT], on_shutdown=lambda: calls.append(True)
+        ) as shutdown:
+            shutdown._handle_shutdown_signal(signal.SIGINT, None)  # first
+            assert len(calls) == 1
+
+            with (
+                mock.patch("keelson.scaffolding.signals.signal.signal"),
+                mock.patch("keelson.scaffolding.signals.signal.raise_signal"),
+            ):
+                shutdown._handle_shutdown_signal(signal.SIGINT, None)  # second
+
+            # on_shutdown ran exactly once, on the first signal only.
+            assert len(calls) == 1
 
     def test_custom_signals(self):
         """Test that custom signals can be specified."""


### PR DESCRIPTION
## Summary

Adds signal escalation to the shared `GracefulShutdown` handler (used by every connector). **PR 3 of the `5.1.0V-trial` split**, reworked from the trial-branch version to fix correctness issues found in review.

Previously, once shutdown was requested the handler ignored every later signal — a second Ctrl+C did nothing, so an operator whose connector was stuck in cleanup had no escape but `kill -9`.

### Behaviour now
- **1st** SIGINT/SIGTERM → request cooperative shutdown (unchanged).
- **2nd** → restore the default disposition **and re-raise the same signal**, so the process terminates immediately. Genuine double-press-to-force.

### Changes vs. the trial-branch original
The trial version only did `signal.signal(signum, SIG_DFL)` without re-raising — so despite a docstring claiming otherwise, it actually took **three** presses (1 graceful, 2 arm default, 3 die). This PR adds `signal.raise_signal(signum)` so the second press forces, and rewrites the docstring to **honestly state the limitation**: Python runs handlers on the main thread at bytecode boundaries and doesn't re-enter the same handler, so the escalation only breaks *interruptible* cleanup (a pure-Python loop or timed wait) — it can't interrupt a hang inside `on_shutdown` or an uninterruptible C call.

## Tests
Adds three tests (the trial version had none):
- first signal requests shutdown without touching disposition;
- second restores `SIG_DFL` and re-raises (mocked so the suite isn't killed);
- `on_shutdown` runs exactly once, not on the escalation path.

`uv run pytest sdks/python/tests/` — **102 passed, 1 skipped**. ruff + black clean.

## Context
This is the kind of long-lived blocking daemon the escalation is for; the upcoming MCAP replay daemon (PR 5) is the first such daemon and benefits directly, though it doesn't strictly depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)