### PR TITLE
feat(mavlink): nav-target + fence telemetry

### DIFF
--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -300,7 +300,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (30 subjects, 15 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (29 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -300,7 +300,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (27 subjects, 13 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (30 subjects, 15 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -92,7 +92,7 @@ subjects, not the liveliness tokens.
 
 ## Published telemetry (uplink)
 
-The connector decodes 13 MAVLink message types and republishes them as typed
+The connector decodes 15 MAVLink message types and republishes them as typed
 Keelson envelopes. Anything not in the table below is dropped at DEBUG.
 
 Every envelope is wrapped in `keelson.Envelope` (with `enclosed_at` set to
@@ -135,6 +135,36 @@ under `<--source-id>/gps_raw` to keep it distinguishable from the
 | `battery_current_a` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
 | `battery_state_of_charge_pct` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
 | `battery_temperature_celsius` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
+| <a id="navigation_target_echo">`navigation_target_echo`</a> | `foxglove.LocationFix` | `POSITION_TARGET_GLOBAL_INT` | `--source-id` |
+| <a id="mission_current_seq">`mission_current_seq`</a> | `keelson.TimestampedInt` | `MISSION_CURRENT` | `--source-id` |
+| <a id="fence_enabled">`fence_enabled`</a> | `keelson.TimestampedBool` | `SYS_STATUS` | `--source-id` |
+
+### Conditional subjects
+
+Three subjects above are **not** part of every stream — they appear only when
+the autopilot supplies the underlying state:
+
+- **`navigation_target_echo`** — the autopilot's echo of its active navigation
+  target (the goto point in GUIDED-style modes), republished as the geographic
+  position only (velocity / accel / yaw from the MAVLink message are dropped).
+  `POSITION_TARGET_GLOBAL_INT` is **not** in ArduPilot's default stream set:
+  `set_navigation_target` requests a single instance to confirm a goto, and an
+  operator who wants a continuous target echo streams it with
+  `set_message_interval` (message `POSITION_TARGET_GLOBAL_INT`). A target of
+  exactly `(0, 0)` — the message's "position fields ignored" sentinel — is
+  skipped.
+- **`mission_current_seq`** — the sequence index of the mission item the
+  autopilot is currently navigating to, for active-leg highlighting. ArduPilot
+  streams `MISSION_CURRENT` at a low periodic rate (and emits one immediately
+  after `set_current_waypoint`), so no stream configuration is needed.
+- **`fence_enabled`** — whether the geofence is **currently being enforced**,
+  surfaced from the `MAV_SYS_STATUS_GEOFENCE` bit of `SYS_STATUS` (the real
+  autopilot state, *not* an echo of the last `enable_geofence` RPC). It
+  reflects ArduPilot's effective `fence.enabled()` — the `FENCE_ENABLE` param
+  plus any RC-switch / auto-enable override. The subject is published **only
+  when a fence subsystem is present** (the `present` bit), so its absence means
+  "no fence configured" while a `False` value means "configured but not
+  enforcing".
 
 ### Rates
 

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -92,7 +92,7 @@ subjects, not the liveliness tokens.
 
 ## Published telemetry (uplink)
 
-The connector decodes 15 MAVLink message types and republishes them as typed
+The connector decodes 14 MAVLink message types and republishes them as typed
 Keelson envelopes. Anything not in the table below is dropped at DEBUG.
 
 Every envelope is wrapped in `keelson.Envelope` (with `enclosed_at` set to
@@ -135,28 +135,27 @@ under `<--source-id>/gps_raw` to keep it distinguishable from the
 | `battery_current_a` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
 | `battery_state_of_charge_pct` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
 | `battery_temperature_celsius` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
-| <a id="navigation_target_echo">`navigation_target_echo`</a> | `foxglove.LocationFix` | `POSITION_TARGET_GLOBAL_INT` | `--source-id` |
-| <a id="mission_current_seq">`mission_current_seq`</a> | `keelson.TimestampedInt` | `MISSION_CURRENT` | `--source-id` |
+| <a id="navigation_target">`navigation_target`</a> | `foxglove.LocationFix` | `POSITION_TARGET_GLOBAL_INT` | `--source-id` |
 | <a id="fence_enabled">`fence_enabled`</a> | `keelson.TimestampedBool` | `SYS_STATUS` | `--source-id` |
 
 ### Conditional subjects
 
-Three subjects above are **not** part of every stream — they appear only when
+Two subjects above are **not** part of every stream — they appear only when
 the autopilot supplies the underlying state:
 
-- **`navigation_target_echo`** — the autopilot's echo of its active navigation
-  target (the goto point in GUIDED-style modes), republished as the geographic
-  position only (velocity / accel / yaw from the MAVLink message are dropped).
+- **`navigation_target`** — the autopilot's **reported active navigation
+  target** (the goto point in GUIDED-style modes); the read-side counterpart to
+  the `set_navigation_target` RPC. It reflects what the autopilot is actually
+  steering to, which may **diverge** from the last commanded target (the
+  autopilot can clamp it, or be following a mission leg instead). Only the
+  geographic position (lat/lon) is published — velocity / accel / yaw are
+  dropped, and so is altitude (its MAVLink frame is `coordinate_frame`-dependent,
+  not WGS84, and is meaningless for a surface vessel).
   `POSITION_TARGET_GLOBAL_INT` is **not** in ArduPilot's default stream set:
   `set_navigation_target` requests a single instance to confirm a goto, and an
-  operator who wants a continuous target echo streams it with
-  `set_message_interval` (message `POSITION_TARGET_GLOBAL_INT`). A target of
-  exactly `(0, 0)` — the message's "position fields ignored" sentinel — is
-  skipped.
-- **`mission_current_seq`** — the sequence index of the mission item the
-  autopilot is currently navigating to, for active-leg highlighting. ArduPilot
-  streams `MISSION_CURRENT` at a low periodic rate (and emits one immediately
-  after `set_current_waypoint`), so no stream configuration is needed.
+  operator who wants a continuous feed streams it with `set_message_interval`
+  (message `POSITION_TARGET_GLOBAL_INT`). A target of exactly `(0, 0)` — the
+  message's "position fields ignored" sentinel — is skipped.
 - **`fence_enabled`** — whether the geofence is **currently being enforced**,
   surfaced from the `MAV_SYS_STATUS_GEOFENCE` bit of `SYS_STATUS` (the real
   autopilot state, *not* an echo of the last `enable_geofence` RPC). It

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -699,35 +699,27 @@ def map_battery_status(msg, ts: int) -> Mapping:
 
 
 def map_position_target_global_int(msg, ts: int) -> Mapping:
-    # The autopilot's echo of its current navigation target (the goto point in
-    # GUIDED-style modes). Republished as a LocationFix so a UI can render
-    # "where the autopilot is steering to" — the velocity / accel / yaw fields
-    # are intentionally dropped, only the geographic target is echoed.
-    #
-    # `lat_int` / `lon_int` are degE7; `alt` is metres in the frame named by
-    # `coordinate_frame` (relative-to-home for ArduPilot's GUIDED targets).
+    # The autopilot's reported active navigation target (the goto point in
+    # GUIDED-style modes) — the read-side counterpart to the
+    # set_navigation_target RPC. Republished as a LocationFix so a UI can render
+    # "where the autopilot is steering to". Only the geographic target (lat/lon)
+    # is published: velocity / accel / yaw are dropped, and so is `alt` — its
+    # frame depends on `coordinate_frame` (relative-to-home for ArduPilot GUIDED
+    # targets, not WGS84), so a single LocationFix.altitude would be mislabelled
+    # and is meaningless for a surface vessel anyway.
     #
     # This message is not in ArduPilot's default stream set: set_navigation_target
     # requests a single instance to confirm a goto (via MAV_CMD_REQUEST_MESSAGE),
-    # and an operator who wants a continuous echo streams it via
+    # and an operator who wants a continuous feed streams it via
     # set_message_interval. A target of exactly (0, 0) means "no active position
     # target" (the type_mask is ignoring the position fields) and is skipped.
     if msg.lat_int == 0 and msg.lon_int == 0:
         return
-    yield "navigation_target_echo", "", enclose_from_location_fix(
+    yield "navigation_target", "", enclose_from_location_fix(
         latitude=msg.lat_int / 1e7,
         longitude=msg.lon_int / 1e7,
-        altitude=float(msg.alt),
         timestamp=ts,
     )
-
-
-def map_mission_current(msg, ts: int) -> Mapping:
-    # Sequence number of the mission item the autopilot is currently navigating
-    # to — drives active-leg highlighting. ArduPilot streams MISSION_CURRENT at
-    # a low periodic rate (and emits one immediately after MISSION_SET_CURRENT),
-    # so this needs no extra stream configuration.
-    yield "mission_current_seq", "", enclose_from_integer(int(msg.seq), timestamp=ts)
 
 
 # Dispatch table. Keyed by MAVLink message-name string (msg.get_type()).
@@ -746,7 +738,6 @@ MESSAGE_HANDLERS: dict[str, Callable[..., Mapping]] = {
     "SCALED_IMU3": map_scaled_imu,
     "BATTERY_STATUS": map_battery_status,
     "POSITION_TARGET_GLOBAL_INT": map_position_target_global_int,
-    "MISSION_CURRENT": map_mission_current,
 }
 
 

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -506,6 +506,21 @@ def map_sys_status(msg, ts: int) -> Mapping:
     yield "entity_health", "", build_entity_health_from_sys_status(msg, ts)
     # SYS_STATUS also reports battery — but BATTERY_STATUS is more complete,
     # so we let that handler own those subjects.
+    #
+    # Geofence enforcement state. ArduPilot reflects the *effective* fence
+    # state in the SYS_STATUS sensor bitmask: MAV_SYS_STATUS_GEOFENCE is set
+    # in `present` when a fence subsystem is configured and in `enabled` when
+    # the fence is currently being enforced (`fence.enabled()`, which folds in
+    # the FENCE_ENABLE param plus any RC-switch / auto-enable override). This
+    # is the autopilot's real state, not an echo of the last enable_geofence
+    # RPC. We only surface `fence_enabled` for vehicles that actually have a
+    # fence subsystem (the `present` bit), so a consumer can tell "fence
+    # disabled" (subject present, value False) apart from "no fence at all"
+    # (subject never appears).
+    geofence_bit = mavlink_dialect.MAV_SYS_STATUS_GEOFENCE
+    if msg.onboard_control_sensors_present & geofence_bit:
+        enforced = bool(msg.onboard_control_sensors_enabled & geofence_bit)
+        yield "fence_enabled", "", enclose_from_bool(enforced, timestamp=ts)
 
 
 def map_global_position_int(msg, ts: int) -> Mapping:
@@ -683,6 +698,38 @@ def map_battery_status(msg, ts: int) -> Mapping:
         )
 
 
+def map_position_target_global_int(msg, ts: int) -> Mapping:
+    # The autopilot's echo of its current navigation target (the goto point in
+    # GUIDED-style modes). Republished as a LocationFix so a UI can render
+    # "where the autopilot is steering to" — the velocity / accel / yaw fields
+    # are intentionally dropped, only the geographic target is echoed.
+    #
+    # `lat_int` / `lon_int` are degE7; `alt` is metres in the frame named by
+    # `coordinate_frame` (relative-to-home for ArduPilot's GUIDED targets).
+    #
+    # This message is not in ArduPilot's default stream set: set_navigation_target
+    # requests a single instance to confirm a goto (via MAV_CMD_REQUEST_MESSAGE),
+    # and an operator who wants a continuous echo streams it via
+    # set_message_interval. A target of exactly (0, 0) means "no active position
+    # target" (the type_mask is ignoring the position fields) and is skipped.
+    if msg.lat_int == 0 and msg.lon_int == 0:
+        return
+    yield "navigation_target_echo", "", enclose_from_location_fix(
+        latitude=msg.lat_int / 1e7,
+        longitude=msg.lon_int / 1e7,
+        altitude=float(msg.alt),
+        timestamp=ts,
+    )
+
+
+def map_mission_current(msg, ts: int) -> Mapping:
+    # Sequence number of the mission item the autopilot is currently navigating
+    # to — drives active-leg highlighting. ArduPilot streams MISSION_CURRENT at
+    # a low periodic rate (and emits one immediately after MISSION_SET_CURRENT),
+    # so this needs no extra stream configuration.
+    yield "mission_current_seq", "", enclose_from_integer(int(msg.seq), timestamp=ts)
+
+
 # Dispatch table. Keyed by MAVLink message-name string (msg.get_type()).
 MESSAGE_HANDLERS: dict[str, Callable[..., Mapping]] = {
     "HEARTBEAT": map_heartbeat,
@@ -698,6 +745,8 @@ MESSAGE_HANDLERS: dict[str, Callable[..., Mapping]] = {
     "SCALED_IMU2": map_scaled_imu,
     "SCALED_IMU3": map_scaled_imu,
     "BATTERY_STATUS": map_battery_status,
+    "POSITION_TARGET_GLOBAL_INT": map_position_target_global_int,
+    "MISSION_CURRENT": map_mission_current,
 }
 
 

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -553,21 +553,23 @@ class TestPositionTargetGlobalInt:
             yaw_rate=0.0,
         )
 
-    def test_emits_navigation_target_echo(self):
+    def test_emits_navigation_target(self):
         out = list(mk.map_position_target_global_int(self._build(), TS))
-        assert [s for s, _, _ in out] == ["navigation_target_echo"]
+        assert [s for s, _, _ in out] == ["navigation_target"]
         assert all(suffix == "" for _, suffix, _ in out)
 
-    def test_decodes_lat_lon_alt(self):
+    def test_decodes_lat_lon(self):
         out = dict(
             (s, env)
             for s, _, env in mk.map_position_target_global_int(self._build(), TS)
         )
-        _, fix = _decode(out["navigation_target_echo"], LocationFix)
+        _, fix = _decode(out["navigation_target"], LocationFix)
         assert fix.latitude == pytest.approx(57.578, rel=1e-6)
         assert fix.longitude == pytest.approx(11.95, rel=1e-6)
-        assert fix.altitude == pytest.approx(5.0, rel=1e-6)
         assert fix.frame_id == "wgs84"
+        # Altitude is intentionally not published (frame-dependent, and
+        # meaningless for a surface vessel) — left at the proto default.
+        assert fix.altitude == 0.0
 
     def test_skips_zero_zero_target(self):
         # (0, 0) means the position fields are being ignored — no active
@@ -576,23 +578,6 @@ class TestPositionTargetGlobalInt:
             mk.map_position_target_global_int(self._build(lat_e7=0, lon_e7=0), TS)
         )
         assert out == []
-
-
-# ---------------------------------------------------------------------------
-# MISSION_CURRENT
-# ---------------------------------------------------------------------------
-
-
-class TestMissionCurrent:
-    def test_emits_mission_current_seq(self):
-        msg = m.MAVLink_mission_current_message(
-            seq=7, total=12, mission_state=0, mission_mode=0
-        )
-        out = list(mk.map_mission_current(msg, TS))
-        assert [s for s, _, _ in out] == ["mission_current_seq"]
-        d = {s: env for s, _, env in out}
-        _, seq = _decode(d["mission_current_seq"], TimestampedInt)
-        assert seq.value == 7
 
 
 # ---------------------------------------------------------------------------

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -118,9 +118,14 @@ class TestHeartbeat:
 # ---------------------------------------------------------------------------
 
 
-def _build_sys_status(enabled_bits=0, healthy_bits=0):
+def _build_sys_status(enabled_bits=0, healthy_bits=0, present_bits=None):
+    # present_bits defaults to enabled_bits (the common case: a sensor that is
+    # enabled is also present). Pass it explicitly to model "configured but
+    # disabled" subsystems — e.g. a geofence present but not enforcing.
+    if present_bits is None:
+        present_bits = enabled_bits
     return m.MAVLink_sys_status_message(
-        onboard_control_sensors_present=enabled_bits,
+        onboard_control_sensors_present=present_bits,
         onboard_control_sensors_enabled=enabled_bits,
         onboard_control_sensors_health=healthy_bits,
         load=500,
@@ -207,6 +212,54 @@ class TestSysStatus:
         _, eh = _decode(out["entity_health"], EntityHealth)
         check_names = {c.name for c in eh.sources[0].subjects[0].checks}
         assert check_names == {"3d_gyro"}
+
+    def test_no_fence_enabled_subject_when_geofence_absent(self):
+        # A vehicle with no geofence subsystem present must not emit
+        # fence_enabled at all (consumers read its absence as "no fence").
+        out = list(
+            mk.map_sys_status(
+                _build_sys_status(
+                    enabled_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
+                    healthy_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
+                ),
+                TS,
+            )
+        )
+        assert "fence_enabled" not in [s for s, _, _ in out]
+
+    def test_fence_enabled_true_when_geofence_enforced(self):
+        # Geofence present AND enabled -> fence_enabled True.
+        out = dict(
+            (s, env)
+            for s, _, env in mk.map_sys_status(
+                _build_sys_status(
+                    enabled_bits=m.MAV_SYS_STATUS_GEOFENCE,
+                    healthy_bits=m.MAV_SYS_STATUS_GEOFENCE,
+                ),
+                TS,
+            )
+        )
+        _, fence = _decode(out["fence_enabled"], TimestampedBool)
+        assert fence.value is True
+
+    def test_fence_enabled_false_when_present_but_disabled(self):
+        # Geofence configured (present) but not currently enforcing (not in
+        # the enabled bitmask) -> fence_enabled False, surfacing the real
+        # autopilot state rather than the last enable_geofence RPC value.
+        out = dict(
+            (s, env)
+            for s, _, env in mk.map_sys_status(
+                _build_sys_status(
+                    enabled_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
+                    healthy_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
+                    present_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO
+                    | m.MAV_SYS_STATUS_GEOFENCE,
+                ),
+                TS,
+            )
+        )
+        _, fence = _decode(out["fence_enabled"], TimestampedBool)
+        assert fence.value is False
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +527,72 @@ class TestBatteryStatus:
         )
         out = list(mk.map_battery_status(msg, TS))
         assert out == []
+
+
+# ---------------------------------------------------------------------------
+# POSITION_TARGET_GLOBAL_INT
+# ---------------------------------------------------------------------------
+
+
+class TestPositionTargetGlobalInt:
+    def _build(self, lat_e7=575780000, lon_e7=119500000, alt_m=5.0):
+        return m.MAVLink_position_target_global_int_message(
+            time_boot_ms=1234,
+            coordinate_frame=m.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+            type_mask=0,
+            lat_int=lat_e7,
+            lon_int=lon_e7,
+            alt=alt_m,
+            vx=0.0,
+            vy=0.0,
+            vz=0.0,
+            afx=0.0,
+            afy=0.0,
+            afz=0.0,
+            yaw=0.0,
+            yaw_rate=0.0,
+        )
+
+    def test_emits_navigation_target_echo(self):
+        out = list(mk.map_position_target_global_int(self._build(), TS))
+        assert [s for s, _, _ in out] == ["navigation_target_echo"]
+        assert all(suffix == "" for _, suffix, _ in out)
+
+    def test_decodes_lat_lon_alt(self):
+        out = dict(
+            (s, env)
+            for s, _, env in mk.map_position_target_global_int(self._build(), TS)
+        )
+        _, fix = _decode(out["navigation_target_echo"], LocationFix)
+        assert fix.latitude == pytest.approx(57.578, rel=1e-6)
+        assert fix.longitude == pytest.approx(11.95, rel=1e-6)
+        assert fix.altitude == pytest.approx(5.0, rel=1e-6)
+        assert fix.frame_id == "wgs84"
+
+    def test_skips_zero_zero_target(self):
+        # (0, 0) means the position fields are being ignored — no active
+        # target, so nothing is published.
+        out = list(
+            mk.map_position_target_global_int(self._build(lat_e7=0, lon_e7=0), TS)
+        )
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# MISSION_CURRENT
+# ---------------------------------------------------------------------------
+
+
+class TestMissionCurrent:
+    def test_emits_mission_current_seq(self):
+        msg = m.MAVLink_mission_current_message(
+            seq=7, total=12, mission_state=0, mission_mode=0
+        )
+        out = list(mk.map_mission_current(msg, TS))
+        assert [s for s, _, _ in out] == ["mission_current_seq"]
+        d = {s: env for s, _, env in out}
+        _, seq = _decode(d["mission_current_seq"], TimestampedInt)
+        assert seq.value == 7
 
 
 # ---------------------------------------------------------------------------

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -20,8 +20,7 @@ entity_health:                          keelson.EntityHealth
 # Vehicle state (autopilot-driven)
 vehicle_mode:                           keelson.TimestampedString  # ArduPilot/PX4 mode name (MANUAL, GUIDED, HOLD, AUTO, ...)
 vehicle_armed:                          keelson.TimestampedBool
-navigation_target_echo:                 foxglove.LocationFix       # Autopilot-side nav target echo (MAVLink POSITION_TARGET_GLOBAL_INT)
-mission_current_seq:                    keelson.TimestampedInt     # Active mission waypoint sequence (MAVLink MISSION_CURRENT)
+navigation_target:                      foxglove.LocationFix       # Autopilot-reported active nav target, lat/lon (MAVLink POSITION_TARGET_GLOBAL_INT)
 fence_enabled:                          keelson.TimestampedBool    # Geofence enforcement active (MAVLink SYS_STATUS geofence bit)
 
 frame_transform:                        foxglove.FrameTransform

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -20,6 +20,9 @@ entity_health:                          keelson.EntityHealth
 # Vehicle state (autopilot-driven)
 vehicle_mode:                           keelson.TimestampedString  # ArduPilot/PX4 mode name (MANUAL, GUIDED, HOLD, AUTO, ...)
 vehicle_armed:                          keelson.TimestampedBool
+navigation_target_echo:                 foxglove.LocationFix       # Autopilot-side nav target echo (MAVLink POSITION_TARGET_GLOBAL_INT)
+mission_current_seq:                    keelson.TimestampedInt     # Active mission waypoint sequence (MAVLink MISSION_CURRENT)
+fence_enabled:                          keelson.TimestampedBool    # Geofence enforcement active (MAVLink SYS_STATUS geofence bit)
 
 frame_transform:                        foxglove.FrameTransform
 


### PR DESCRIPTION
## Summary

Adds two uplink telemetry subjects to the MAVLink connector. Split out of the trial-branch parameter-metadata commit (`bee299f`) and **trimmed after review** to the two subjects that earn their place.

| Subject | Payload | Source | Notes |
|---------|---------|--------|-------|
| `navigation_target` | `foxglove.LocationFix` | `POSITION_TARGET_GLOBAL_INT` | Autopilot's **reported active** goto target (lat/lon), the read-side counterpart to the `set_navigation_target` RPC. May diverge from the last commanded target. A `(0,0)` target (the "position fields ignored" sentinel) is skipped. |
| `fence_enabled` | `keelson.TimestampedBool` | `SYS_STATUS` geofence bit | The autopilot's real `fence.enabled()` state. **Emitted only when a fence subsystem is present** (the `present` bit), so a consumer distinguishes "no fence configured" (subject absent) from "configured but not enforcing" (value `False`). |

### Changed after review
- **Dropped `mission_current_seq`.** A bare MAVLink `seq` is only interpretable by re-indexing into a `Mission` downloaded via the RPC, has no change signal, and discards `mission_state`. Rather than publish a subject (a contract) we already consider the wrong shape, the useful form — a resolved `MissionItem` with context — is folded into the shared domain-type design discussion, **#153**.
- **Renamed `navigation_target_echo` → `navigation_target`.** The `_echo` leaked MAVLink mechanism; commands are RPCs, so every pub/sub subject is reported state by definition — nothing to disambiguate against. `navigation_target` reads cleanly as the read-side counterpart to `set_navigation_target`.
- **Dropped altitude from `navigation_target`.** `POSITION_TARGET_GLOBAL_INT.alt` is in a `coordinate_frame`-dependent frame (relative-to-home for ArduPilot GUIDED), so a `LocationFix.altitude` labelled `wgs84` was mislabelled — and altitude is meaningless for a surface vessel. lat/lon only.

`fence_enabled` is unchanged — the present-vs-enabled gating is the thoughtful bit and needed nothing.

## Applied onto current main, not cherry-picked
The trial branch is based on an older main, so I applied only these telemetry additions onto current main's `mavlink2keelson.py` as targeted edits — no unrelated churn.

## Validation
- `uv run pytest connectors/mavlink/tests/test_mavlink_mapping.py` — **35 passed** (fence present/enabled/absent states, nav-target lat/lon decode + altitude-absent + (0,0) skip, dispatch-table coverage).
- Both subjects resolve to real message classes; ruff + black clean; Python + JS SDKs regenerate.
- Docs updated (ZENOH_API telemetry table + conditional-subjects section; README counts → 29 subjects, 14 message types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)