### PR TITLE
feat: parameter metadata mechanism + mavlink republishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ sdks/python/keelson/payloads
 sdks/python/keelson/interfaces
 sdks/python/keelson/*_pb2*
 sdks/python/keelson/subjects.yaml
+sdks/python/keelson/parameter_definitions.yaml
 sdks/python/keelson/procedures.yaml
 *Zone.Identifier
 __pycache__

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -300,7 +300,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (29 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (30 subjects: 29 from 14 MAVLink message types + `parameter_metadata` from Keelson) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -180,6 +180,32 @@ from `GPS_RAW_INT`). They have different latency and reliability
 characteristics; consumers usually want the EKF-fused one. The raw fix is
 exposed for diagnostics and for the GPS-injection round-trip case.
 
+### Parameter metadata (Keelson-sourced, not MAVLink)
+
+| Subject | Payload type | Source | source_id |
+| --- | --- | --- | --- |
+| <a id="parameter_metadata">`parameter_metadata`</a> | `keelson.ParameterMetadataList` | Keelson `parameter_definitions.yaml` | `--source-id` |
+
+The one published subject **not** decoded from a MAVLink frame. MAVLink's
+PARAM protocol carries only id / value / type — no units, range, or
+description — so that metadata is **authored in Keelson** (the bundled
+`parameter_definitions.yaml`, exposed via `keelson.get_parameter_definitions()`)
+and the connector simply republishes it. A UI joins it by `name` to the live
+values from the `VehicleParam` RPCs to render parameter editors with units,
+bounds, defaults, and help text.
+
+Each `ParameterMetadata` entry carries `name`, optional `units`, `range_min` /
+`range_max`, `increment`, `default_value`, `description`, an enum `values`
+map (`code -> label`), and a `read_only` flag. Optional numeric fields are
+left **unset** (proto3 `optional`) when the definition omits them, so a
+consumer can tell "no bound" from "a bound of 0".
+
+The metadata is static, so the connector publishes it **once at startup and
+re-publishes every 30 s** (see `PARAM_METADATA_REPUBLISH_S`) so late
+subscribers still receive it without a router storage backend. The subject is
+absent only when the connector runs against a keelson SDK build that predates
+the type or bundles no definitions.
+
 ---
 
 ## Subscribed inputs (downlink)

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -125,6 +125,15 @@ from keelson.interfaces.MavlinkCommand_pb2 import (
 from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
 from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+
+try:
+    # Static parameter metadata — units / range / description, authored in
+    # Keelson and republished on the `parameter_metadata` subject. Guarded so
+    # the connector still starts against an older keelson SDK build that
+    # predates the type (the feature just self-disables).
+    from keelson.payloads.ParameterMetadata_pb2 import ParameterMetadataList
+except ImportError:  # pragma: no cover - depends on installed SDK build
+    ParameterMetadataList = None
 from keelson.scaffolding import (
     GracefulShutdown,
     add_common_arguments,
@@ -790,6 +799,71 @@ def dispatch(
     except Exception:  # noqa: BLE001 — never let a single bad msg kill the loop
         logger.exception("Failed to dispatch %s", msg.get_type())
     return published
+
+
+# ---------------------------------------------------------------------------
+# Parameter metadata
+#
+# MAVLink's PARAM protocol carries only id / value / type — no units, range,
+# or description. Keelson owns that metadata (authored in
+# messages/parameter_definitions.yaml, bundled into the SDK and exposed via
+# keelson.get_parameter_definitions()); the connector simply republishes it on
+# the `parameter_metadata` subject so a UI can decorate the live PARAM stream.
+# It is static, so it is published once at startup and re-published at a low
+# rate for late subscribers.
+# ---------------------------------------------------------------------------
+
+PARAM_METADATA_REPUBLISH_S = 30.0
+
+
+def _parameter_metadata_envelope(
+    definitions: dict, timestamp_ns: int
+) -> Optional[bytes]:
+    """Build an enclosed ``keelson.ParameterMetadataList`` from the Keelson
+    definitions mapping (``name -> attrs``). Returns ``None`` when the SDK
+    build lacks the type or no definitions are bundled."""
+    if ParameterMetadataList is None or not definitions:
+        return None
+    payload = ParameterMetadataList()
+    payload.timestamp.FromNanoseconds(timestamp_ns)
+    for name in sorted(definitions):
+        attrs = definitions[name] or {}
+        entry = payload.params.add()
+        entry.name = name
+        if attrs.get("units") is not None:
+            entry.units = str(attrs["units"])
+        rng = attrs.get("range")
+        if isinstance(rng, (list, tuple)) and len(rng) == 2:
+            if rng[0] is not None:
+                entry.range_min = float(rng[0])
+            if rng[1] is not None:
+                entry.range_max = float(rng[1])
+        if attrs.get("increment") is not None:
+            entry.increment = float(attrs["increment"])
+        if attrs.get("default") is not None:
+            entry.default_value = float(attrs["default"])
+        if attrs.get("description") is not None:
+            entry.description = str(attrs["description"])
+        for code, label in (attrs.get("values") or {}).items():
+            entry.values[int(code)] = str(label)
+        if attrs.get("read_only"):
+            entry.read_only = True
+    return enclose(payload.SerializeToString())
+
+
+def _publish_parameter_metadata(
+    session: "zenoh.Session", args: argparse.Namespace, definitions: dict
+) -> int:
+    """Publish the Keelson-held parameter metadata on ``parameter_metadata``.
+    Returns the number of parameters published (0 when nothing to publish)."""
+    envelope = _parameter_metadata_envelope(definitions, time.time_ns())
+    if envelope is None:
+        return 0
+    pub = _get_or_create_publisher(
+        session, args.realm, args.entity_id, "parameter_metadata", args.source_id
+    )
+    pub.put(envelope)
+    return len(definitions)
 
 
 # ---------------------------------------------------------------------------
@@ -4028,12 +4102,42 @@ def run(args: argparse.Namespace) -> int:
                 session, args, mav, args.target_component
             )
 
+            # Parameter metadata: republish Keelson's parameter definitions
+            # (units / range / description) on `parameter_metadata` so a UI can
+            # decorate the live PARAM_VALUE stream. Static data, so publish
+            # once now and re-publish at a low rate (below) for late
+            # subscribers.
+            parameter_definitions = (
+                keelson.get_parameter_definitions()
+                if hasattr(keelson, "get_parameter_definitions")
+                else {}
+            )
+            published_params = _publish_parameter_metadata(
+                session, args, parameter_definitions
+            )
+            if published_params:
+                logger.info(
+                    "Published parameter_metadata for %d parameter(s)",
+                    published_params,
+                )
+            else:
+                logger.info(
+                    "No parameter metadata to publish (none bundled with the "
+                    "keelson SDK build)"
+                )
+            next_param_metadata_at = time.monotonic() + PARAM_METADATA_REPUBLISH_S
+
             # Recv runs on its own thread; the main thread polls the rate
             # monitor (self-rate-limited to once every 2 s) and the
             # link-loss watchdog, then waits for shutdown.
             while not shutdown.is_requested():
                 shutdown.wait(timeout=1.0)
                 rate_monitor.check()
+                if published_params and time.monotonic() >= next_param_metadata_at:
+                    _publish_parameter_metadata(session, args, parameter_definitions)
+                    next_param_metadata_at = (
+                        time.monotonic() + PARAM_METADATA_REPUBLISH_S
+                    )
                 if link_dead[0] and not is_tlog:
                     # A TCP transport reported EOF/disconnect — a definite
                     # link loss, no need to wait out --link-timeout.

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -24,6 +24,7 @@ from keelson.payloads.Primitives_pb2 import (
 )
 from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+from keelson.payloads.ParameterMetadata_pb2 import ParameterMetadataList
 
 
 TS = 1_700_000_000_000_000_000  # fixed nanosecond timestamp for determinism
@@ -578,6 +579,63 @@ class TestPositionTargetGlobalInt:
             mk.map_position_target_global_int(self._build(lat_e7=0, lon_e7=0), TS)
         )
         assert out == []
+
+
+# ---------------------------------------------------------------------------
+# Parameter metadata (Keelson-held definitions -> parameter_metadata)
+# ---------------------------------------------------------------------------
+
+
+class TestParameterMetadata:
+    DEFS = {
+        "CRUISE_SPEED": {
+            "units": "m/s",
+            "range": [0, 100],
+            "increment": 0.1,
+            "default": 2.0,
+            "description": "Target speed.",
+        },
+        "FENCE_ACTION": {
+            "values": {0: "Report only", 1: "RTL or Hold"},
+            "description": "Breach action.",
+        },
+        "RO_PARAM": {"read_only": True},
+    }
+
+    def test_envelope_decodes_scalar_fields(self):
+        env = mk._parameter_metadata_envelope(self.DEFS, TS)
+        assert env is not None
+        _, lst = _decode(env, ParameterMetadataList)
+        by = {p.name: p for p in lst.params}
+        assert set(by) == {"CRUISE_SPEED", "FENCE_ACTION", "RO_PARAM"}
+        cs = by["CRUISE_SPEED"]
+        assert cs.units == "m/s"
+        assert cs.range_min == 0.0 and cs.range_max == 100.0
+        assert cs.increment == pytest.approx(0.1)
+        assert cs.default_value == pytest.approx(2.0)
+        assert cs.description == "Target speed."
+
+    def test_enum_values_and_unset_optionals(self):
+        env = mk._parameter_metadata_envelope(self.DEFS, TS)
+        _, lst = _decode(env, ParameterMetadataList)
+        by = {p.name: p for p in lst.params}
+        fa = by["FENCE_ACTION"]
+        assert dict(fa.values) == {0: "Report only", 1: "RTL or Hold"}
+        # No range / increment given -> proto3 optionals stay unset, so a
+        # consumer can distinguish "no bound" from "bound of 0".
+        assert not fa.HasField("range_min")
+        assert not fa.HasField("increment")
+        assert fa.units == ""
+        assert by["RO_PARAM"].read_only is True
+
+    def test_empty_definitions_returns_none(self):
+        assert mk._parameter_metadata_envelope({}, TS) is None
+
+    def test_params_sorted_by_name(self):
+        env = mk._parameter_metadata_envelope(self.DEFS, TS)
+        _, lst = _decode(env, ParameterMetadataList)
+        names = [p.name for p in lst.params]
+        assert names == sorted(names)
 
 
 # ---------------------------------------------------------------------------

--- a/messages/parameter_definitions.yaml
+++ b/messages/parameter_definitions.yaml
@@ -1,0 +1,97 @@
+### Well-known parameter definitions ###
+#
+# Static, human-facing metadata for onboard control parameters — units, valid
+# range, increment, factory default, description, and enum value labels. The
+# MAVLink PARAM protocol carries none of this over the wire, so Keelson is the
+# source of truth: connectors join this metadata to the live PARAM_VALUE
+# stream and republish it on the `parameter_metadata` subject
+# (keelson.ParameterMetadataList) so a UI can render parameter editors with
+# units, bounds, and help text.
+#
+# Keyed by the parameter id as the autopilot reports it. Per-entry fields
+# (all optional):
+#   units        engineering unit string, e.g. "m/s", "deg", "%"
+#   range        [min, max] inclusive valid range
+#   increment    recommended editor step
+#   default      factory default value
+#   description  human-readable help text
+#   values       {code: label} for enumerated parameters
+#   read_only    true when reported but not settable
+#
+# This is an initial curated set focused on the ArduPilot Rover / surface-boat
+# parameters a maritime HMI surfaces; extend it as more parameters need
+# editor-grade metadata. Values follow ArduPilot's parameter documentation.
+
+CRUISE_SPEED:
+  units: m/s
+  range: [0, 100]
+  increment: 0.1
+  description: Target speed in automatic throttle modes (AUTO, GUIDED, RTL). The autopilot steers and throttles to hold this speed.
+
+CRUISE_THROTTLE:
+  units: "%"
+  range: [0, 100]
+  increment: 1
+  description: Base throttle percentage in automatic modes, calibrated to roughly produce CRUISE_SPEED on flat water.
+
+WP_RADIUS:
+  units: m
+  range: [0, 1000]
+  increment: 0.1
+  description: Distance from a waypoint at which it counts as reached and the vehicle advances to the next leg.
+
+WP_OVERSHOOT:
+  units: m
+  range: [0, 10]
+  increment: 0.1
+  description: Maximum cross-track overshoot the navigation controller tolerates when cornering between waypoints.
+
+TURN_MAX_G:
+  units: gravities
+  range: [0.2, 10]
+  increment: 0.1
+  description: Maximum lateral acceleration in turns. Lower values give gentler, wider turns.
+
+ATC_STR_RAT_MAX:
+  units: deg/s
+  range: [0, 1000]
+  description: Maximum commanded steering (yaw) rate — caps how fast the autopilot will rotate the vehicle.
+
+FENCE_ENABLE:
+  values: {0: Disabled, 1: Enabled}
+  description: Master switch for geofence enforcement. When enabled, the configured fences are checked and FENCE_ACTION is taken on breach.
+
+FENCE_TYPE:
+  description: Bitmask of enabled fence geometries (bit 0 = max altitude, bit 1 = circle, bit 2 = polygon, bit 3 = min altitude). 0 disables all fence geometry.
+
+FENCE_ACTION:
+  values: {0: Report only, 1: RTL or Hold, 2: Hold, 3: SmartRTL or Hold, 4: Brake or Hold}
+  description: Action the vehicle takes when the geofence is breached.
+
+FENCE_RADIUS:
+  units: m
+  range: [30, 10000]
+  increment: 1
+  description: Radius of the circular geofence centred on the home position.
+
+FENCE_MARGIN:
+  units: m
+  range: [1, 10]
+  increment: 1
+  description: Distance inside the fence at which the autopilot begins avoiding action.
+
+BATT_CAPACITY:
+  units: mAh
+  range: [0, 1000000]
+  description: Battery capacity in milliamp-hours, used to estimate remaining charge.
+
+BATT_LOW_VOLT:
+  units: V
+  range: [0, 100]
+  increment: 0.1
+  description: Battery voltage below which the low-battery failsafe triggers. 0 disables the voltage failsafe.
+
+SYSID_MYGCS:
+  range: [1, 255]
+  default: 255
+  description: MAVLink system id this autopilot accepts manual-control / RC-override from. Must match the connector's source-system for stick driving to take effect.

--- a/messages/payloads/ParameterMetadata.proto
+++ b/messages/payloads/ParameterMetadata.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+package keelson;
+
+// Static, human-facing metadata describing a single onboard control
+// parameter — the information MAVLink's PARAM protocol does NOT carry over
+// the wire (units, valid range, help text). It is authored and
+// version-controlled in the Keelson project as the source of truth, and
+// republished by connectors so a UI can render parameter editors with units,
+// bounds, defaults, and descriptions.
+message ParameterMetadata {
+  // Parameter identifier as the autopilot reports it, e.g. "CRUISE_SPEED".
+  string name = 1;
+  // Engineering unit, e.g. "m/s", "deg", "A". Empty when dimensionless.
+  string units = 2;
+  // Inclusive valid range. The field is omitted (proto3 optional, unset)
+  // when the parameter is unbounded on that side.
+  optional double range_min = 3;
+  optional double range_max = 4;
+  // Recommended adjustment step for editor spinners. Unset when not defined.
+  optional double increment = 5;
+  // Factory default value. Unset when the definition does not declare one.
+  optional double default_value = 6;
+  // Human-readable description / help text.
+  string description = 7;
+  // For enumerated parameters: numeric code -> human label
+  // (e.g. {0: "Disabled", 1: "RTL", 2: "Hold"}). Empty for scalar params.
+  map<int32, string> values = 8;
+  // True when the parameter is reported but not settable.
+  bool read_only = 9;
+}
+
+// A batch of parameter definitions — e.g. the full set a connector knows for
+// a vehicle. Published on the `parameter_metadata` subject; `timestamp` is
+// when the batch was produced at source.
+message ParameterMetadataList {
+  google.protobuf.Timestamp timestamp = 1;
+  repeated ParameterMetadata params = 2;
+}

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -22,6 +22,7 @@ vehicle_mode:                           keelson.TimestampedString  # ArduPilot/P
 vehicle_armed:                          keelson.TimestampedBool
 navigation_target:                      foxglove.LocationFix       # Autopilot-reported active nav target, lat/lon (MAVLink POSITION_TARGET_GLOBAL_INT)
 fence_enabled:                          keelson.TimestampedBool    # Geofence enforcement active (MAVLink SYS_STATUS geofence bit)
+parameter_metadata:                     keelson.ParameterMetadataList  # Static param definitions (units/range/description); authored in Keelson, republished by connectors
 
 frame_transform:                        foxglove.FrameTransform
 

--- a/sdks/python/generate_python.sh
+++ b/sdks/python/generate_python.sh
@@ -13,7 +13,11 @@ rm -rf keelson/**/**/*_pb2*
 
 # Copy tags.yaml (forcing an overwrite)
 echo "	Copying subjects.yaml..."
-cp -rf ../../messages/subjects.yaml keelson/subjects.yaml 
+cp -rf ../../messages/subjects.yaml keelson/subjects.yaml
+
+# Copy the well-known parameter definitions (bundled like subjects.yaml)
+echo "	Copying parameter_definitions.yaml..."
+cp -rf ../../messages/parameter_definitions.yaml keelson/parameter_definitions.yaml
 
 # Generate code for Envelope.proto
 echo "	Generating code for Envelope.proto..."

--- a/sdks/python/keelson/__init__.py
+++ b/sdks/python/keelson/__init__.py
@@ -340,3 +340,45 @@ def is_subject_well_known(subject: str) -> bool:
 
 def get_subject_schema(subject: str) -> str:
     return _SUBJECTS[subject]
+
+
+# ---------------------------------------------------------------------------
+# Well-known parameter definitions
+#
+# Static, human-facing metadata for onboard control parameters (units, range,
+# description, ...) that the MAVLink PARAM protocol does not carry over the
+# wire. Authored in the Keelson `messages/parameter_definitions.yaml` tree as
+# the source of truth and bundled into the SDK; connectors republish it on the
+# `parameter_metadata` subject (keelson.ParameterMetadataList). See that proto
+# for the field contract.
+# ---------------------------------------------------------------------------
+
+_PARAMETER_DEFINITIONS = {}
+
+
+def add_parameter_definitions(path_to_parameter_definitions_yaml: Path):
+    with path_to_parameter_definitions_yaml.open() as fh:
+        _PARAMETER_DEFINITIONS.update(yaml.safe_load(fh) or {})
+
+
+# Bundled definitions are optional — guarded so an SDK build without the file
+# (older generators) imports cleanly rather than crashing at import time.
+_parameter_definitions_path = _PACKAGE_ROOT / "parameter_definitions.yaml"
+if _parameter_definitions_path.exists():
+    add_parameter_definitions(_parameter_definitions_path)
+
+
+def get_parameter_definitions() -> dict:
+    """Return the bundled parameter metadata, keyed by parameter name.
+
+    Each value is a mapping with the optional keys ``units``, ``range``
+    (``[min, max]``), ``increment``, ``default``, ``description``, ``values``
+    (``{code: label}``) and ``read_only``. Empty when no definitions are
+    bundled with the SDK build.
+    """
+    return dict(_PARAMETER_DEFINITIONS)
+
+
+def get_parameter_definition(name: str):
+    """Return the metadata mapping for a single parameter, or ``None``."""
+    return _PARAMETER_DEFINITIONS.get(name)

--- a/sdks/python/tests/test_sdk.py
+++ b/sdks/python/tests/test_sdk.py
@@ -334,3 +334,38 @@ def test_get_subject_from_pubsub_key_with_target():
         )
         == "heading_true_north_deg"
     )
+
+
+# ---------------------------------------------------------------------------
+# Parameter definitions registry
+# ---------------------------------------------------------------------------
+
+
+def test_parameter_metadata_subject_is_well_known():
+    assert keelson.is_subject_well_known("parameter_metadata")
+    assert keelson.get_subject_schema("parameter_metadata") == (
+        "keelson.ParameterMetadataList"
+    )
+
+
+def test_get_parameter_definitions_returns_bundled_set():
+    defs = keelson.get_parameter_definitions()
+    assert isinstance(defs, dict)
+    assert "CRUISE_SPEED" in defs
+    assert defs["CRUISE_SPEED"]["units"] == "m/s"
+    assert defs["CRUISE_SPEED"]["range"] == [0, 100]
+    # Returns a copy — callers can't mutate the registry.
+    defs["CRUISE_SPEED"] = None
+    assert keelson.get_parameter_definitions()["CRUISE_SPEED"] is not None
+
+
+def test_get_parameter_definition_single_and_enum_keys():
+    fence = keelson.get_parameter_definition("FENCE_ACTION")
+    assert fence is not None
+    # YAML loads the enum codes as ints, matching the map<int32, string> proto.
+    assert all(isinstance(code, int) for code in fence["values"])
+    assert fence["values"][0] == "Report only"
+
+
+def test_get_parameter_definition_unknown_returns_none():
+    assert keelson.get_parameter_definition("NOT_A_REAL_PARAM") is None


### PR DESCRIPTION
## Summary

Adds a Keelson-owned **parameter metadata** mechanism and wires the MAVLink connector to republish it. This is the `(1)+(2)` split of the trial-branch commit `bee299f` — the generic SDK mechanism plus its only consumer (mavlink), bundled together because the mechanism has no other user (same reasoning that folded `ErrorResponse.Code` into the replay PR).

> ⚠️ **Stacked on #148** (`feat/mavlink-nav-fence-telemetry`). The base of this PR is that branch, so the diff here shows only the param-metadata changes. Merge #148 first (or this will auto-retarget to `main` once #148 lands). The two share `mavlink2keelson.py`, the test file, `subjects.yaml`, README and ZENOH_API, which is why this is stacked rather than independent.

### SDK mechanism (1)
- New `keelson.ParameterMetadata` / `ParameterMetadataList` proto.
- `messages/parameter_definitions.yaml` — authored source of truth (~14 ArduPilot Rover params: units / range / increment / default / description / enum `values` / `read_only`), bundled into the SDK like `subjects.yaml` (copied by `generate_python.sh`, gitignored).
- `keelson.add_parameter_definitions` / `get_parameter_definitions` / `get_parameter_definition`, loaded from the bundled file — guarded so an older SDK build without the file still imports cleanly.
- New `parameter_metadata` subject → `keelson.ParameterMetadataList`.

### MAVLink republishing (2)
- Guard-imports `ParameterMetadataList` (feature self-disables against an SDK that predates the type).
- Builds the list from `keelson.get_parameter_definitions()` and publishes on `parameter_metadata` **once at startup, re-published every 30 s** for late subscribers (no router storage needed). proto3 `optional` fields keep "no bound" distinct from "bound of 0".

## Validation
- `uv run pytest sdks/python/tests/` — **31 passed** (loader/registry: subject well-known, bundled set, copy-not-reference, enum int keys, unknown→None).
- `uv run pytest connectors/mavlink/tests/test_mavlink_mapping.py` — **40 passed** (envelope builder: scalar fields, enum values + unset optionals, empty→None, sorted output).
- Full SDK suite green; `mavlink2keelson --help` runs; Python + JS SDKs regenerate cleanly; ruff + black clean.

## Review notes (extracted as-authored)
- `get_parameter_definitions()` returns a **shallow** copy — mutating a nested value would mutate the registry (tests cover the top-level copy only). Low risk for a read-mostly registry.
- JS SDK gets the proto but **no** `get_parameter_definitions` loader / bundled YAML — follow-up if JS parity is wanted.
- I omitted the trial commit's `VehicleParam` RPC-section cross-reference note (consistent with #148) to avoid matching diverged doc text; the subject is fully documented in its own ZENOH_API section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)