### PR TITLE
docs: typed interfaces over generic vendor catalogs

### DIFF
--- a/connectors/CLAUDE.md
+++ b/connectors/CLAUDE.md
@@ -153,6 +153,44 @@ cleanly abstract across autopilot stacks), say so in the proto comment.
 Don't leave it to future readers to figure out from the connector source.
 The proto is the contract; the comment is part of it.
 
+### Typed interfaces over generic catalogs; keep vendor reference data off the bus
+
+When an operator needs to read or change a specific value, model it as a
+typed, vehicle-agnostic RPC or subject named for the domain concept — not as
+a generic key-value / "parameter" bag. The typed form gives callers a stable
+vocabulary, makes the legal operations discoverable, and turns mistakes into
+build errors. This is the same instinct as *Closed sets over opaque escape
+hatches*, applied to configuration and tuning. It's also the rule behind two
+decisions already made: every `cmd_*` pub/sub command became a typed RPC, and
+the `keelson.ManualControl` payload was removed in favour of existing
+`joystick_*` subjects.
+
+- **Don't put an external system's reference catalog on the bus.** An
+  autopilot's parameter table (units / range / description), command
+  numbering, or mode list is firmware-owned, versioned per release, and
+  drifts out-of-band. A hand-maintained Keelson copy is a second source of
+  truth that goes stale and is wrong for the firmware actually running. If
+  such metadata is genuinely needed, **pull it from its authoritative source**
+  (e.g. the vehicle's component-metadata) rather than copying it.
+- **Don't bundle vendor- or connector-specific data into the core SDK.** The
+  `keelson` SDK is the vehicle-agnostic transport / envelope / subject
+  toolkit. A connector-specific catalog and its loader belong with the
+  connector, not as a global SDK API that every consumer (foxglove, ais, a
+  dashboard) inherits.
+- **Promote the values that need live control to typed RPCs** (e.g.
+  `set_cruise_speed`). Comprehensive parameter *tuning* is a ground-control-
+  station job, served better by a GCS reading firmware-accurate metadata than
+  by a curated copy on the bus.
+
+**Rejected design (concrete):** a `parameter_metadata` subject carrying a
+hand-authored YAML catalog of ~14 ArduPilot params, bundled into the keelson
+SDK (`keelson.get_parameter_definitions()`) and republished by the connector
+([PR #149](https://github.com/RISE-Maritime/keelson/pull/149)). Rejected
+because it created a second, drift-prone source of truth for firmware-owned
+data and pushed autopilot-specific data into the vehicle-agnostic SDK. The
+operator-facing params it targeted (cruise speed, …) are better served by
+typed RPCs; full tuning belongs in a GCS.
+
 ## Standard Layout
 
 ```

--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -1,11 +1,37 @@
-# Interfaces  
+# Interfaces
 
 **Work In Progress!!**
 **Use with caution!!**
 
 **Interfaces** in keelson are specifications of collections of rpc endpoints, i.e. remote function signatures. A single interface may contain any number of rpc endpoints. The interfaces are described using the protobuf service syntax.
 
+## Design principles
 
+These shape what belongs in an interface and how it should be modelled. The
+full, worked-out list (with rationale and examples) lives in
+[`connectors/CLAUDE.md` → "Interface design principles"](../connectors/CLAUDE.md);
+the headlines:
 
-
-
+- **Keep external protocol shapes out of interfaces.** No degE7 / fixed-point
+  scaling, magic command numbers, or opaque `(param1..param4)` blobs. Interfaces
+  are vehicle-agnostic — any connector implementing the same protocol should be
+  able to expose the same contract.
+- **Closed typed sets over opaque escape hatches.** Use `oneof` over a typed
+  set for variant data rather than a discriminator + opaque payload. Where a
+  raw pass-through is genuinely needed, expose it as a separate, intentionally
+  protocol-shaped RPC and document the leak (e.g. `MavlinkCommand`).
+- **Pick RPC vs pub/sub by data shape.** One-shot commands / queries with a
+  typed success/failure are RPCs; continuous streams are pub/sub. A `cmd_*`
+  subject almost always wants to be an RPC.
+- **Reuse existing subjects for the data plane.** A connector's interface is
+  the *configuration of which keys to use*, not a new payload type for data
+  that an existing subject already carries.
+- **Typed interfaces over generic catalogs; keep vendor reference data off the
+  bus.** Model a specific operator action as a typed RPC named for the domain
+  concept — not a generic key-value / "parameter" bag. Don't carry an external
+  system's reference catalog (autopilot parameter tables, command numbering,
+  mode lists) on the bus or bundle it into the core SDK: it's firmware-owned,
+  versioned per release, and drifts. If such metadata is genuinely needed, pull
+  it from its authoritative source. Values that need live control should each
+  become a typed RPC (e.g. `set_cruise_speed`); comprehensive parameter tuning
+  is a ground-control-station job.

--- a/sdks/python/CLAUDE.md
+++ b/sdks/python/CLAUDE.md
@@ -67,3 +67,4 @@ Registered as `zenoh_cli.codecs.encoders` and `zenoh_cli.codecs.decoders`:
 - Connector `bin/` scripts are standalone executables, not importable packages. Use `SourceFileLoader` to import them in tests (see `connectors/CLAUDE.md`).
 - If you add exports to scaffolding modules, update `scaffolding/__init__.py` and its `__all__` list.
 - `utils.py` is deprecated — do not add new code there.
+- The SDK is **vehicle- and vendor-agnostic** — the transport / envelope / subject toolkit, nothing more. Don't bundle connector- or vendor-specific data (e.g. an autopilot's parameter catalog) or expose APIs for it from the `keelson` package; that data belongs with the connector that owns it. See the "Typed interfaces over generic catalogs" principle in `connectors/CLAUDE.md`.


### PR DESCRIPTION
## Summary

Adds an explicit interface-design principle to the repo: **model operator actions as typed, vehicle-agnostic RPCs/subjects rather than generic key-value catalogs, and keep external-system reference data off the bus and out of the core SDK.**

This generalises two decisions already baked into the connector (every `cmd_*` pub/sub command became a typed RPC; the `keelson.ManualControl` payload was removed in favour of existing `joystick_*` subjects), and gives the project a citable doctrine for the next time the question comes up.

It is also the **stated basis for rejecting #149** (the `parameter_metadata` catalog), which is cited as the worked "rejected design" example.

## Changes
- **`connectors/CLAUDE.md`** — new principle under *Interface design principles* (canonical home), including the concrete rejected-design example (#149) and the reasoning: a hand-authored autopilot-parameter catalog on the bus is a second, drift-prone source of truth for firmware-owned data, and pushes vendor-specific data into the vehicle-agnostic SDK.
- **`interfaces/README.md`** — fleshes out the WIP stub with a human-facing design-principles summary that links to the canonical list.
- **`sdks/python/CLAUDE.md`** — layering note: the SDK is the vendor-agnostic transport/envelope/subject toolkit; don't bundle vendor-specific data or APIs into it.

## The principle (gist)
> When an operator needs to read or change a specific value, model it as a typed RPC/subject named for the domain concept — not a generic "parameter" bag. Don't carry an external system's reference catalog (param tables, command numbering, mode lists) on the bus or in the core SDK — it's firmware-owned, versioned, and drifts; pull it from its authoritative source if genuinely needed. Promote values that need live control to typed RPCs (e.g. `set_cruise_speed`); comprehensive tuning is a GCS job.

Docs-only; no code or generated artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)