### PR TITLE
Bug/double heartbeat

### DIFF
--- a/connectors/CLAUDE.md
+++ b/connectors/CLAUDE.md
@@ -121,10 +121,16 @@ value can override.
 
 Declare exactly one liveliness token per connector at session-open time and
 undeclare it on clean shutdown. Treat it as "this process is connected to
-Zenoh." Don't gate on external-system readiness — that's a different signal
-(use `entity_health` republished from the protocol's heartbeat / status
-stream for that). An aggregator rolling up health across multiple sources
-should consume the typed health subject, not the liveliness token.
+Zenoh." Don't gate on external-system readiness — that's a different signal.
+Publish the external system's own health/status as **raw** Keelson subjects
+(the MAVLink connector republishes per-sensor `sensor_status` and a
+`vehicle_state` from the autopilot's heartbeat / status stream) and let a
+dedicated aggregator — the `entity_health` connector — roll those up into
+`EntityHealth` by watching `(source, subject)` pairs. A connector should
+**not** compute and publish `entity_health` itself: that bakes health
+*policy* (what's nominal vs critical) into the connector, and two emitters
+writing the same `entity_health` key race and flip-flop. Use the freshness of
+the raw subjects (and the liveliness token for connector-alive) instead.
 
 ### Stream semantics: silence is a signal too
 

--- a/connectors/mavlink/GETTING-STARTED.md
+++ b/connectors/mavlink/GETTING-STARTED.md
@@ -267,8 +267,8 @@ z_sub -k "rise/@v0/motorboat-01/pubsub/**"
 ```
 
 Within a few seconds you should see envelopes flowing for the standard
-telemetry subjects (`vehicle_mode`, `vehicle_armed`, `entity_health`,
-`location_fix`, `roll_deg`, `battery_voltage_v`, `speed_over_ground_knots`,
+telemetry subjects (`vehicle_mode`, `vehicle_armed`, `location_fix`,
+`roll_deg`, `battery_voltage_v`, `speed_over_ground_knots`,
 …). If you don't, see Troubleshooting below.
 
 To record everything to MCAP for later replay or Foxglove viewing:

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -304,7 +304,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `sensor_status`, … (29 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `sensor_status`, `vehicle_state`, … (30 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 
@@ -316,8 +316,8 @@ both: existing Keelson subjects on the data plane, operator-declared
 mapping on the control plane.
 
 The liveliness token signals **connector-alive**, not vehicle-alive. Use
-the freshness of the autopilot telemetry (e.g. `vehicle_mode`, published on
-every MAVLink HEARTBEAT) for vehicle liveness.
+the freshness of `vehicle_state` (published on every MAVLink HEARTBEAT) for
+vehicle liveness.
 
 ---
 

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -92,7 +92,7 @@ mavlink2keelson \
 z_sub -k "test/@v0/sitl/pubsub/**"
 ```
 
-You should see `vehicle_mode`, `vehicle_armed`, `entity_health`,
+You should see `vehicle_mode`, `vehicle_armed`,
 `location_fix`, `roll_deg`, … envelopes flowing.
 
 ---
@@ -156,11 +156,10 @@ Two related details:
   you also want to filter by which subsystem on the vehicle (autopilot,
   gimbal, companion computer, …) sent the message. For most vehicles you
   can leave it at the default; ArduPilot's autopilot is component `1`. Note
-  that `vehicle_mode` / `vehicle_armed` / `entity_health` are derived only
-  from the autopilot's HEARTBEAT (one whose `autopilot` field is a real flight
-  controller, not `MAV_AUTOPILOT_INVALID`), regardless of this flag — so a
-  GCS or companion computer that shares the system id can't make those
-  subjects flip-flop.
+  that `vehicle_mode` / `vehicle_armed` are derived only from the autopilot's
+  HEARTBEAT (one whose `autopilot` field is a real flight controller, not
+  `MAV_AUTOPILOT_INVALID`), regardless of this flag — so a GCS or companion
+  computer that shares the system id can't make those subjects flip-flop.
 
 The flag pairs with `--entity-id`: **one MAVLink vehicle = one keelson
 entity = one connector instance.** If you have two vehicles on the same
@@ -305,7 +304,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `entity_health`, … (29 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, … (28 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 
@@ -317,8 +316,8 @@ both: existing Keelson subjects on the data plane, operator-declared
 mapping on the control plane.
 
 The liveliness token signals **connector-alive**, not vehicle-alive. Use
-the freshness of `entity_health` (republished from every MAVLink HEARTBEAT)
-for vehicle liveness.
+the freshness of the autopilot telemetry (e.g. `vehicle_mode`, published on
+every MAVLink HEARTBEAT) for vehicle liveness.
 
 ---
 

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -304,7 +304,7 @@ Three categories of traffic across these keys:
 
 | Direction | Pattern | Examples | Where to look |
 | --- | --- | --- | --- |
-| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, … (28 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
+| Uplink | Pub/sub publish (Keelson Envelopes wrapping typed payloads) | `vehicle_mode`, `location_fix`, `roll_deg`, `sensor_status`, … (29 subjects, 14 source MAVLink message types) | [ZENOH_API.md § Published telemetry](./ZENOH_API.md#published-telemetry-uplink) |
 | Downlink data | Pub/sub *subscribe* on existing controller-input + telemetry subjects | `joystick_x_pct` → MAVLink `RC_CHANNELS_OVERRIDE`; `location_fix` (with a different source_id) → MAVLink `GPS_INPUT` | [§ Manual control](./ZENOH_API.md#manual-control), [§ Sensor injection](./ZENOH_API.md#sensor-injection) |
 | Commands | Queryable RPCs (20 procedures across 6 `Vehicle*` services + 1 escape hatch) | `arm`, `set_mode`, `upload_mission`, `set_navigation_target`, `get_param`, … | [§ RPC services](./ZENOH_API.md#rpc-services) |
 

--- a/connectors/mavlink/README.md
+++ b/connectors/mavlink/README.md
@@ -155,7 +155,12 @@ Two related details:
 - `--target-component` (default `0` = "any component") narrows further if
   you also want to filter by which subsystem on the vehicle (autopilot,
   gimbal, companion computer, …) sent the message. For most vehicles you
-  can leave it at the default; ArduPilot's autopilot is component `1`.
+  can leave it at the default; ArduPilot's autopilot is component `1`. Note
+  that `vehicle_mode` / `vehicle_armed` / `entity_health` are derived only
+  from the autopilot's HEARTBEAT (one whose `autopilot` field is a real flight
+  controller, not `MAV_AUTOPILOT_INVALID`), regardless of this flag — so a
+  GCS or companion computer that shares the system id can't make those
+  subjects flip-flop.
 
 The flag pairs with `--entity-id`: **one MAVLink vehicle = one keelson
 entity = one connector instance.** If you have two vehicles on the same

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -83,10 +83,10 @@ clean shutdown. Key:
 
 **Semantics: connector-alive, not vehicle-alive.** Treat the token's presence
 as "the connector process is running and connected to Zenoh." Use the
-freshness of [`entity_health`](#entity_health) (republished from every MAVLink
-HEARTBEAT) for vehicle liveness. An aggregator rolling up health across
-multiple sources should consume `entity_health` from this and similar
-subjects, not the liveliness tokens.
+freshness of the autopilot telemetry (e.g. `vehicle_mode`, published on every
+MAVLink HEARTBEAT) for vehicle liveness. An aggregator rolling up health
+should consume the raw health subjects the connector publishes, not the
+liveliness tokens.
 
 ---
 
@@ -110,7 +110,6 @@ under `<--source-id>/gps_raw` to keep it distinguishable from the
 | --- | --- | --- | --- |
 | `vehicle_mode` | `keelson.TimestampedString` | `HEARTBEAT` | `--source-id` |
 | `vehicle_armed` | `keelson.TimestampedBool` | `HEARTBEAT` | `--source-id` |
-| <a id="entity_health">`entity_health`</a> | `keelson.EntityHealth` | `HEARTBEAT`, `SYS_STATUS` | `--source-id` |
 | `location_fix` | `foxglove.LocationFix` | `GLOBAL_POSITION_INT` | `--source-id` |
 | `location_fix` | `foxglove.LocationFix` | `GPS_RAW_INT` | `<--source-id>/gps_raw` |
 | `altitude_above_msl_m` | `keelson.TimestampedFloat` | `GLOBAL_POSITION_INT` | `--source-id` |

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -83,10 +83,11 @@ clean shutdown. Key:
 
 **Semantics: connector-alive, not vehicle-alive.** Treat the token's presence
 as "the connector process is running and connected to Zenoh." Use the
-freshness of the autopilot telemetry (e.g. `vehicle_mode`, published on every
-MAVLink HEARTBEAT) for vehicle liveness. An aggregator rolling up health
-should consume the raw health subjects the connector publishes, not the
-liveliness tokens.
+freshness of [`vehicle_state`](#vehicle_state) (published on every MAVLink
+HEARTBEAT, ~1 Hz) for vehicle liveness. An aggregator rolling up health should
+consume the raw health subjects the connector publishes —
+[`vehicle_state`](#vehicle_state) and [`sensor_status`](#sensor_status) — not
+the liveliness tokens.
 
 ---
 
@@ -110,8 +111,9 @@ is fanned out per subsystem under `<--source-id>/<sensor>` (e.g.
 
 | Subject | Payload type | Source MAVLink message | source_id |
 | --- | --- | --- | --- |
-| `vehicle_mode` | `keelson.TimestampedString` | `HEARTBEAT` | `--source-id` |
+| <a id="vehicle_mode">`vehicle_mode`</a> | `keelson.TimestampedString` | `HEARTBEAT` | `--source-id` |
 | `vehicle_armed` | `keelson.TimestampedBool` | `HEARTBEAT` | `--source-id` |
+| <a id="vehicle_state">`vehicle_state`</a> | `keelson.VehicleState` | `HEARTBEAT` | `--source-id` |
 | `location_fix` | `foxglove.LocationFix` | `GLOBAL_POSITION_INT` | `--source-id` |
 | `location_fix` | `foxglove.LocationFix` | `GPS_RAW_INT` | `<--source-id>/gps_raw` |
 | `altitude_above_msl_m` | `keelson.TimestampedFloat` | `GLOBAL_POSITION_INT` | `--source-id` |

--- a/connectors/mavlink/ZENOH_API.md
+++ b/connectors/mavlink/ZENOH_API.md
@@ -101,10 +101,12 @@ before publishing. Inner-payload types are referenced by name; see
 [`messages/payloads/`](../../messages/payloads/) for the proto definitions.
 
 **Source-id convention.** Most subjects publish under the connector's bare
-`--source-id`. The single exception is the `location_fix` derived from
-`GPS_RAW_INT` — the raw fix from the GPS receiver itself — which publishes
-under `<--source-id>/gps_raw` to keep it distinguishable from the
-`location_fix` derived from `GLOBAL_POSITION_INT` (the EKF-fused output).
+`--source-id`. Two use a suffix: the `location_fix` derived from `GPS_RAW_INT`
+— the raw fix from the GPS receiver itself — publishes under
+`<--source-id>/gps_raw` to keep it distinguishable from the `location_fix`
+derived from `GLOBAL_POSITION_INT` (the EKF-fused output); and `sensor_status`
+is fanned out per subsystem under `<--source-id>/<sensor>` (e.g.
+`<--source-id>/gps`, see [`sensor_status`](#sensor_status) below).
 
 | Subject | Payload type | Source MAVLink message | source_id |
 | --- | --- | --- | --- |
@@ -136,6 +138,7 @@ under `<--source-id>/gps_raw` to keep it distinguishable from the
 | `battery_temperature_celsius` | `keelson.TimestampedFloat` | `BATTERY_STATUS` | `--source-id` |
 | <a id="navigation_target">`navigation_target`</a> | `foxglove.LocationFix` | `POSITION_TARGET_GLOBAL_INT` | `--source-id` |
 | <a id="fence_enabled">`fence_enabled`</a> | `keelson.TimestampedBool` | `SYS_STATUS` | `--source-id` |
+| <a id="sensor_status">`sensor_status`</a> | `keelson.SensorStatus` | `SYS_STATUS` | `<--source-id>/<sensor>` |
 
 ### Conditional subjects
 
@@ -163,6 +166,18 @@ the autopilot supplies the underlying state:
   when a fence subsystem is present** (the `present` bit), so its absence means
   "no fence configured" while a `False` value means "configured but not
   enforcing".
+- **`sensor_status`** — per-subsystem health from the `SYS_STATUS`
+  present/enabled/health bitmasks, **fanned out by `source_id` suffix**: one
+  publish per *present* subsystem under `<--source-id>/<sensor>`. The curated
+  set is `attitude_estimator`, `gps`, `arming_checks`, `remote_control`,
+  `compass`, `gyroscope`, `accelerometer`, `geofence`, `data_logging`. The bits
+  map to `SensorStatus.OperatingMode`: enabled + healthy → `RUNNING`, enabled +
+  unhealthy → `ERROR`, present but not enabled → `STANDBY`; a subsystem that is
+  not present emits nothing (absence = "not equipped"). The connector only
+  translates the bits — assigning a NOMINAL/CRITICAL **health verdict** is the
+  `entity_health` connector's job, which can watch these `(source, subject)`
+  pairs. (The `geofence` `sensor_status` reports subsystem *health*; the
+  separate `fence_enabled` bool reports *enforcement* state.)
 
 ### Rates
 

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -495,6 +495,17 @@ Mapping = Iterable[Tuple[str, str, bytes]]
 
 
 def map_heartbeat(msg, ts: int) -> Mapping:
+    # Only the autopilot's HEARTBEAT defines the vehicle's mode / armed /
+    # health. Other components on the same system (a GCS, companion computer,
+    # gimbal, MAVProxy forward) also emit HEARTBEAT at ~1 Hz, and with the
+    # default --target-component 0 ("any component") they reach us too. Mapping
+    # them onto the same source_id makes vehicle_mode / vehicle_armed flip-flop
+    # every second between the real autopilot and the impostor. Per the MAVLink
+    # spec a non-flight-controller sets autopilot = MAV_AUTOPILOT_INVALID, so we
+    # use that to keep only the real autopilot — the same predicate
+    # _wait_boot_heartbeat() uses to pick the autopilot out of a shared system.
+    if msg.autopilot == mavlink_dialect.MAV_AUTOPILOT_INVALID:
+        return
     mode_name = mavutil.mode_string_v10(msg)
     armed = bool(msg.base_mode & mavlink_dialect.MAV_MODE_FLAG_SAFETY_ARMED)
     yield "vehicle_mode", "", enclose_from_string(mode_name, timestamp=ts)

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -57,6 +57,7 @@ from keelson.payloads.Primitives_pb2 import (
     TimestampedQuaternion,
 )
 from keelson.payloads.SensorStatus_pb2 import SensorStatus
+from keelson.payloads.VehicleState_pb2 import VehicleState
 from keelson.interfaces.VehicleCommon_pb2 import CommandResult, Coordinate
 from keelson.interfaces.VehicleNavigation_pb2 import (
     NavigationTarget,
@@ -274,6 +275,15 @@ def enclose_from_sensor_status(
     return enclose(payload.SerializeToString())
 
 
+def enclose_from_vehicle_state(
+    state: "VehicleState.State.V", timestamp: Optional[int] = None
+) -> bytes:
+    payload = VehicleState()
+    payload.timestamp.FromNanoseconds(timestamp or time.time_ns())
+    payload.state = state
+    return enclose(payload.SerializeToString())
+
+
 def enclose_from_quaternion(
     w: float, x: float, y: float, z: float, timestamp: Optional[int] = None
 ) -> bytes:
@@ -421,6 +431,21 @@ def enclose_from_location_fix_quality(
 Mapping = Iterable[Tuple[str, str, bytes]]
 
 
+# MAVLink HEARTBEAT MAV_STATE -> vehicle-agnostic VehicleState.State. 1:1; an
+# unrecognised value falls back to STATE_UNKNOWN.
+_MAV_STATE_TO_VEHICLE_STATE = {
+    mavlink_dialect.MAV_STATE_UNINIT: VehicleState.STATE_UNKNOWN,
+    mavlink_dialect.MAV_STATE_BOOT: VehicleState.STATE_BOOTING,
+    mavlink_dialect.MAV_STATE_CALIBRATING: VehicleState.STATE_CALIBRATING,
+    mavlink_dialect.MAV_STATE_STANDBY: VehicleState.STATE_STANDBY,
+    mavlink_dialect.MAV_STATE_ACTIVE: VehicleState.STATE_ACTIVE,
+    mavlink_dialect.MAV_STATE_CRITICAL: VehicleState.STATE_CRITICAL,
+    mavlink_dialect.MAV_STATE_EMERGENCY: VehicleState.STATE_EMERGENCY,
+    mavlink_dialect.MAV_STATE_POWEROFF: VehicleState.STATE_SHUTDOWN,
+    mavlink_dialect.MAV_STATE_FLIGHT_TERMINATION: VehicleState.STATE_TERMINATED,
+}
+
+
 def map_heartbeat(msg, ts: int) -> Mapping:
     # Only the autopilot's HEARTBEAT defines the vehicle's mode / armed state.
     # Other components on the same system (a GCS, companion computer, gimbal,
@@ -435,8 +460,12 @@ def map_heartbeat(msg, ts: int) -> Mapping:
         return
     mode_name = mavutil.mode_string_v10(msg)
     armed = bool(msg.base_mode & mavlink_dialect.MAV_MODE_FLAG_SAFETY_ARMED)
+    state = _MAV_STATE_TO_VEHICLE_STATE.get(
+        msg.system_status, VehicleState.STATE_UNKNOWN
+    )
     yield "vehicle_mode", "", enclose_from_string(mode_name, timestamp=ts)
     yield "vehicle_armed", "", enclose_from_bool(armed, timestamp=ts)
+    yield "vehicle_state", "", enclose_from_vehicle_state(state, timestamp=ts)
 
 
 # SYS_STATUS subsystem bits we surface as per-sensor `sensor_status`, keyed by

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -51,13 +51,6 @@ from keelson.helpers import (
     enclose_from_string,
 )
 from keelson.payloads.Decomposed3DVector_pb2 import Decomposed3DVector
-from keelson.payloads.EntityHealth_pb2 import (
-    CheckResult,
-    EntityHealth,
-    HealthLevel,
-    SourceHealth,
-    SubjectHealth,
-)
 from keelson.payloads.Primitives_pb2 import (
     TimestampedBool,
     TimestampedFloat,
@@ -405,82 +398,6 @@ def enclose_from_location_fix_quality(
 
 
 # ---------------------------------------------------------------------------
-# EntityHealth from HEARTBEAT / SYS_STATUS
-# ---------------------------------------------------------------------------
-
-
-def _health_level_from_mav_state(mav_state: int) -> "HealthLevel.V":
-    """Translate a MAV_STATE value to a keelson HealthLevel."""
-    mapping = {
-        mavlink_dialect.MAV_STATE_UNINIT: HealthLevel.HEALTH_UNKNOWN,
-        mavlink_dialect.MAV_STATE_BOOT: HealthLevel.HEALTH_INACTIVE,
-        mavlink_dialect.MAV_STATE_CALIBRATING: HealthLevel.HEALTH_DEGRADED,
-        mavlink_dialect.MAV_STATE_STANDBY: HealthLevel.HEALTH_NOMINAL,
-        mavlink_dialect.MAV_STATE_ACTIVE: HealthLevel.HEALTH_NOMINAL,
-        mavlink_dialect.MAV_STATE_CRITICAL: HealthLevel.HEALTH_CRITICAL,
-        mavlink_dialect.MAV_STATE_EMERGENCY: HealthLevel.HEALTH_CRITICAL,
-        mavlink_dialect.MAV_STATE_POWEROFF: HealthLevel.HEALTH_INACTIVE,
-        mavlink_dialect.MAV_STATE_FLIGHT_TERMINATION: HealthLevel.HEALTH_CRITICAL,
-    }
-    return mapping.get(mav_state, HealthLevel.HEALTH_UNKNOWN)
-
-
-def build_entity_health_from_heartbeat(msg, timestamp_ns: int) -> bytes:
-    """Build a minimal EntityHealth envelope from a HEARTBEAT message."""
-    payload = EntityHealth()
-    payload.timestamp.FromNanoseconds(timestamp_ns)
-    payload.level = _health_level_from_mav_state(msg.system_status)
-    payload.rate_hz = 1.0  # HEARTBEAT is canonically 1 Hz from ArduPilot.
-    return enclose(payload.SerializeToString())
-
-
-def build_entity_health_from_sys_status(msg, timestamp_ns: int) -> bytes:
-    """Build EntityHealth from SYS_STATUS, with per-sensor CheckResults."""
-    payload = EntityHealth()
-    payload.timestamp.FromNanoseconds(timestamp_ns)
-
-    enabled = msg.onboard_control_sensors_enabled
-    health = msg.onboard_control_sensors_health
-
-    source = SourceHealth()
-    source.name = "onboard_sensors"
-    subject = SubjectHealth()
-    subject.name = "sensors"
-    overall = HealthLevel.HEALTH_NOMINAL
-
-    # Walk the named bits in MAV_SYS_STATUS_SENSOR.
-    for attr in dir(mavlink_dialect):
-        if not attr.startswith("MAV_SYS_STATUS_SENSOR_"):
-            continue
-        bit = getattr(mavlink_dialect, attr)
-        if not isinstance(bit, int) or bit <= 0:
-            continue
-        # Real sensor bits are single-bit powers of two; sentinels like
-        # MAV_SYS_STATUS_SENSOR_ENUM_END are multi-bit and must be skipped.
-        if bit & (bit - 1):
-            continue
-        if not (enabled & bit):
-            continue
-        check = CheckResult()
-        check.name = attr.removeprefix("MAV_SYS_STATUS_SENSOR_").lower()
-        if health & bit:
-            check.level = HealthLevel.HEALTH_NOMINAL
-            check.detail = "ok"
-        else:
-            check.level = HealthLevel.HEALTH_DEGRADED
-            check.detail = "sensor reports unhealthy"
-            overall = HealthLevel.HEALTH_DEGRADED
-        subject.checks.append(check)
-
-    subject.level = overall
-    source.subjects.append(subject)
-    source.level = overall
-    payload.sources.append(source)
-    payload.level = overall
-    return enclose(payload.SerializeToString())
-
-
-# ---------------------------------------------------------------------------
 # MAVLink message -> (subject, source_id_suffix, envelope_bytes) mappers
 #
 # Each mapper is a pure function: takes a parsed mavlink message and a
@@ -495,14 +412,14 @@ Mapping = Iterable[Tuple[str, str, bytes]]
 
 
 def map_heartbeat(msg, ts: int) -> Mapping:
-    # Only the autopilot's HEARTBEAT defines the vehicle's mode / armed /
-    # health. Other components on the same system (a GCS, companion computer,
-    # gimbal, MAVProxy forward) also emit HEARTBEAT at ~1 Hz, and with the
-    # default --target-component 0 ("any component") they reach us too. Mapping
-    # them onto the same source_id makes vehicle_mode / vehicle_armed flip-flop
-    # every second between the real autopilot and the impostor. Per the MAVLink
-    # spec a non-flight-controller sets autopilot = MAV_AUTOPILOT_INVALID, so we
-    # use that to keep only the real autopilot — the same predicate
+    # Only the autopilot's HEARTBEAT defines the vehicle's mode / armed state.
+    # Other components on the same system (a GCS, companion computer, gimbal,
+    # MAVProxy forward) also emit HEARTBEAT at ~1 Hz, and with the default
+    # --target-component 0 ("any component") they reach us too. Mapping them
+    # onto the same source_id makes vehicle_mode / vehicle_armed flip-flop every
+    # second between the real autopilot and the impostor. Per the MAVLink spec a
+    # non-flight-controller sets autopilot = MAV_AUTOPILOT_INVALID, so we use
+    # that to keep only the real autopilot — the same predicate
     # _wait_boot_heartbeat() uses to pick the autopilot out of a shared system.
     if msg.autopilot == mavlink_dialect.MAV_AUTOPILOT_INVALID:
         return
@@ -510,11 +427,9 @@ def map_heartbeat(msg, ts: int) -> Mapping:
     armed = bool(msg.base_mode & mavlink_dialect.MAV_MODE_FLAG_SAFETY_ARMED)
     yield "vehicle_mode", "", enclose_from_string(mode_name, timestamp=ts)
     yield "vehicle_armed", "", enclose_from_bool(armed, timestamp=ts)
-    yield "entity_health", "", build_entity_health_from_heartbeat(msg, ts)
 
 
 def map_sys_status(msg, ts: int) -> Mapping:
-    yield "entity_health", "", build_entity_health_from_sys_status(msg, ts)
     # SYS_STATUS also reports battery — but BATTERY_STATUS is more complete,
     # so we let that handler own those subjects.
     #
@@ -3547,8 +3462,8 @@ def _handle_set_mode(mav, args, op: RpcOp, target_component: int) -> None:
     # Best-effort observation of the mode the autopilot now reports.
     # HEARTBEAT is ~1 Hz so wait a bit longer than that. Using subscribe()
     # rather than recv_match means the telemetry dispatch hook also sees
-    # every HEARTBEAT during this window — no stalled vehicle_mode/
-    # entity_health publishing while a set_mode RPC is in flight.
+    # every HEARTBEAT during this window — no stalled vehicle_mode
+    # publishing while a set_mode RPC is in flight.
     mode_actual = ""
     hb_deadline = time.monotonic() + 1.5
     with subscribe(mav, types=("HEARTBEAT",), name="set_mode_hb") as sub:

--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -56,6 +56,7 @@ from keelson.payloads.Primitives_pb2 import (
     TimestampedFloat,
     TimestampedQuaternion,
 )
+from keelson.payloads.SensorStatus_pb2 import SensorStatus
 from keelson.interfaces.VehicleCommon_pb2 import CommandResult, Coordinate
 from keelson.interfaces.VehicleNavigation_pb2 import (
     NavigationTarget,
@@ -264,6 +265,15 @@ def enclose_from_bool(value: bool, timestamp: Optional[int] = None) -> bytes:
     return enclose(payload.SerializeToString())
 
 
+def enclose_from_sensor_status(
+    mode: "SensorStatus.OperatingMode.V", timestamp: Optional[int] = None
+) -> bytes:
+    payload = SensorStatus()
+    payload.timestamp.FromNanoseconds(timestamp or time.time_ns())
+    payload.mode = mode
+    return enclose(payload.SerializeToString())
+
+
 def enclose_from_quaternion(
     w: float, x: float, y: float, z: float, timestamp: Optional[int] = None
 ) -> bytes:
@@ -429,6 +439,26 @@ def map_heartbeat(msg, ts: int) -> Mapping:
     yield "vehicle_armed", "", enclose_from_bool(armed, timestamp=ts)
 
 
+# SYS_STATUS subsystem bits we surface as per-sensor `sensor_status`, keyed by
+# the source_id suffix the subject publishes under (e.g.
+# sensor_status/<source-id>/gps). This is a curated subset relevant to a
+# surface / autonomous vehicle, not the full ~30-bit MAV_SYS_STATUS_SENSOR
+# space. NB the dialect constant names are inconsistent — some carry the
+# `_SENSOR_` infix, some (AHRS, PREARM_CHECK, GEOFENCE, LOGGING) don't — so the
+# table lists each explicitly rather than walking a name prefix.
+SENSOR_STATUS_BITS: Tuple[Tuple[str, int], ...] = (
+    ("attitude_estimator", mavlink_dialect.MAV_SYS_STATUS_AHRS),
+    ("gps", mavlink_dialect.MAV_SYS_STATUS_SENSOR_GPS),
+    ("arming_checks", mavlink_dialect.MAV_SYS_STATUS_PREARM_CHECK),
+    ("remote_control", mavlink_dialect.MAV_SYS_STATUS_SENSOR_RC_RECEIVER),
+    ("compass", mavlink_dialect.MAV_SYS_STATUS_SENSOR_3D_MAG),
+    ("gyroscope", mavlink_dialect.MAV_SYS_STATUS_SENSOR_3D_GYRO),
+    ("accelerometer", mavlink_dialect.MAV_SYS_STATUS_SENSOR_3D_ACCEL),
+    ("geofence", mavlink_dialect.MAV_SYS_STATUS_GEOFENCE),
+    ("data_logging", mavlink_dialect.MAV_SYS_STATUS_LOGGING),
+)
+
+
 def map_sys_status(msg, ts: int) -> Mapping:
     # SYS_STATUS also reports battery — but BATTERY_STATUS is more complete,
     # so we let that handler own those subjects.
@@ -443,10 +473,31 @@ def map_sys_status(msg, ts: int) -> Mapping:
     # fence subsystem (the `present` bit), so a consumer can tell "fence
     # disabled" (subject present, value False) apart from "no fence at all"
     # (subject never appears).
+    present = msg.onboard_control_sensors_present
+    enabled = msg.onboard_control_sensors_enabled
+    health = msg.onboard_control_sensors_health
+
     geofence_bit = mavlink_dialect.MAV_SYS_STATUS_GEOFENCE
-    if msg.onboard_control_sensors_present & geofence_bit:
-        enforced = bool(msg.onboard_control_sensors_enabled & geofence_bit)
+    if present & geofence_bit:
+        enforced = bool(enabled & geofence_bit)
         yield "fence_enabled", "", enclose_from_bool(enforced, timestamp=ts)
+
+    # Per-subsystem health as `sensor_status`, fanned out by source_id suffix.
+    # One subject per *present* subsystem; a missing suffix means the vehicle
+    # doesn't have it (same "absence is a signal" convention as fence_enabled).
+    # We only translate the autopilot's present/enabled/health bits to an
+    # OperatingMode — we do NOT assign a health verdict (nominal/critical); that
+    # policy lives in the entity_health connector's config. The geofence
+    # sensor_status is the subsystem *health*; fence_enabled above is the
+    # orthogonal *enforcement* state — both intentionally coexist.
+    for suffix, bit in SENSOR_STATUS_BITS:
+        if not (present & bit):
+            continue
+        if enabled & bit:
+            mode = SensorStatus.RUNNING if (health & bit) else SensorStatus.ERROR
+        else:
+            mode = SensorStatus.STANDBY
+        yield "sensor_status", f"/{suffix}", enclose_from_sensor_status(mode, ts)
 
 
 def map_global_position_int(msg, ts: int) -> Mapping:

--- a/connectors/mavlink/tests/test_mavlink_e2e.py
+++ b/connectors/mavlink/tests/test_mavlink_e2e.py
@@ -202,6 +202,7 @@ def _expected_channels() -> set[str]:
     return {
         "vehicle_mode",
         "vehicle_armed",
+        "vehicle_state",
         "sensor_status",
         "location_fix",
         "altitude_above_msl_m",
@@ -465,6 +466,7 @@ def _expected_sitl_channels() -> set[str]:
         # HEARTBEAT
         "vehicle_mode",
         "vehicle_armed",
+        "vehicle_state",
         # SYS_STATUS
         "sensor_status",
         # ATTITUDE

--- a/connectors/mavlink/tests/test_mavlink_e2e.py
+++ b/connectors/mavlink/tests/test_mavlink_e2e.py
@@ -28,7 +28,6 @@ from pymavlink import mavutil
 from pymavlink.dialects.v20 import ardupilotmega as m
 
 from keelson import construct_pubsub_key, construct_rpc_key, enclose
-from keelson.payloads.EntityHealth_pb2 import EntityHealth, HealthLevel
 from keelson.payloads.Primitives_pb2 import (
     TimestampedBool,
     TimestampedFloat,
@@ -175,7 +174,6 @@ def _expected_channels() -> set[str]:
     return {
         "vehicle_mode",
         "vehicle_armed",
-        "entity_health",
         "location_fix",
         "altitude_above_msl_m",
         "heading_true_north_deg",
@@ -438,7 +436,6 @@ def _expected_sitl_channels() -> set[str]:
         # HEARTBEAT
         "vehicle_mode",
         "vehicle_armed",
-        "entity_health",
         # ATTITUDE
         "roll_deg",
         "pitch_deg",
@@ -597,19 +594,6 @@ def test_sitl_telemetry_values(connector_process_factory, temp_dir, zenoh_endpoi
     assert all(
         mv in rover_modes for mv in mode_values
     ), f"Saw unexpected vehicle_mode values: {set(mode_values) - rover_modes}"
-
-    # ---- HEARTBEAT-derived: entity_health envelopes deserialize as EntityHealth ----
-    healths = [EntityHealth.FromString(b) for b in by_subject["entity_health"]]
-    assert healths, "no entity_health messages"
-    # At least one report should be in a known HealthLevel enum value (sanity).
-    known_levels = {
-        HealthLevel.HEALTH_NOMINAL,
-        HealthLevel.HEALTH_DEGRADED,
-        HealthLevel.HEALTH_CRITICAL,
-        HealthLevel.HEALTH_INACTIVE,
-        HealthLevel.HEALTH_UNKNOWN,
-    }
-    assert any(h.level in known_levels for h in healths)
 
     # ---- GLOBAL_POSITION_INT-derived: lat/lon near CMAC home, altitude within ±100m ----
     fixes = [LocationFix.FromString(b) for b in by_subject["location_fix"]]

--- a/connectors/mavlink/tests/test_mavlink_e2e.py
+++ b/connectors/mavlink/tests/test_mavlink_e2e.py
@@ -69,8 +69,9 @@ def _frame_with_ts(frame: bytes, ts_us: int) -> bytes:
 
 
 def _generate_tlog(path: Path) -> None:
-    """Write a small synthetic tlog containing a HEARTBEAT, GLOBAL_POSITION_INT,
-    GPS_RAW_INT, ATTITUDE, VFR_HUD, and BATTERY_STATUS message."""
+    """Write a small synthetic tlog containing a HEARTBEAT, SYS_STATUS,
+    GLOBAL_POSITION_INT, GPS_RAW_INT, ATTITUDE, VFR_HUD, and BATTERY_STATUS
+    message."""
     # The MAVLink encoder needs a "file-like" writer; we build frames using
     # pack() directly.  pack() needs a MAVLink object as context for system_id /
     # component_id / sequence — easiest is to instantiate one with stub writes.
@@ -95,6 +96,33 @@ def _generate_tlog(path: Path) -> None:
         mavlink_version=3,
     )
     out.append(_frame_with_ts(hb.pack(mav), base_ts))
+
+    # SYS_STATUS with a few subsystems present+enabled+healthy so the connector
+    # emits per-sensor `sensor_status` (gyroscope, accelerometer, compass, gps,
+    # attitude_estimator).
+    sensor_bits = (
+        m.MAV_SYS_STATUS_SENSOR_3D_GYRO
+        | m.MAV_SYS_STATUS_SENSOR_3D_ACCEL
+        | m.MAV_SYS_STATUS_SENSOR_3D_MAG
+        | m.MAV_SYS_STATUS_SENSOR_GPS
+        | m.MAV_SYS_STATUS_AHRS
+    )
+    ss = m.MAVLink_sys_status_message(
+        onboard_control_sensors_present=sensor_bits,
+        onboard_control_sensors_enabled=sensor_bits,
+        onboard_control_sensors_health=sensor_bits,
+        load=500,
+        voltage_battery=12000,
+        current_battery=-1,
+        battery_remaining=-1,
+        drop_rate_comm=0,
+        errors_comm=0,
+        errors_count1=0,
+        errors_count2=0,
+        errors_count3=0,
+        errors_count4=0,
+    )
+    out.append(_frame_with_ts(ss.pack(mav), base_ts + 500))
 
     gp = m.MAVLink_global_position_int_message(
         time_boot_ms=1234,
@@ -174,6 +202,7 @@ def _expected_channels() -> set[str]:
     return {
         "vehicle_mode",
         "vehicle_armed",
+        "sensor_status",
         "location_fix",
         "altitude_above_msl_m",
         "heading_true_north_deg",
@@ -436,6 +465,8 @@ def _expected_sitl_channels() -> set[str]:
         # HEARTBEAT
         "vehicle_mode",
         "vehicle_armed",
+        # SYS_STATUS
+        "sensor_status",
         # ATTITUDE
         "roll_deg",
         "pitch_deg",

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -41,11 +41,17 @@ def _decode(envelope_bytes, message_class):
 # ---------------------------------------------------------------------------
 
 
-def _build_heartbeat(armed=True, mode=m.MAV_STATE_ACTIVE, custom_mode=10):
+def _build_heartbeat(
+    armed=True,
+    mode=m.MAV_STATE_ACTIVE,
+    custom_mode=10,
+    autopilot=m.MAV_AUTOPILOT_ARDUPILOTMEGA,
+    type=m.MAV_TYPE_SURFACE_BOAT,
+):
     base = m.MAV_MODE_FLAG_SAFETY_ARMED if armed else 0
     return m.MAVLink_heartbeat_message(
-        type=m.MAV_TYPE_SURFACE_BOAT,
-        autopilot=m.MAV_AUTOPILOT_ARDUPILOTMEGA,
+        type=type,
+        autopilot=autopilot,
         base_mode=base | m.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
         custom_mode=custom_mode,
         system_status=mode,
@@ -58,6 +64,21 @@ class TestHeartbeat:
         out = list(mk.map_heartbeat(_build_heartbeat(), TS))
         subjects = [s for s, _, _ in out]
         assert subjects == ["vehicle_mode", "vehicle_armed", "entity_health"]
+
+    def test_non_autopilot_heartbeat_is_dropped(self):
+        # A GCS / companion / gimbal sharing the system id sets
+        # autopilot=MAV_AUTOPILOT_INVALID. Its HEARTBEAT must NOT drive
+        # vehicle_mode / vehicle_armed / entity_health — otherwise those
+        # subjects flip-flop every second between the real autopilot and the
+        # impostor (the "double heartbeat" bug). It carries the armed bit but a
+        # bogus custom_mode, mirroring the observed Mode(0x80)/armed stream.
+        impostor = _build_heartbeat(
+            armed=True,
+            custom_mode=0,
+            autopilot=m.MAV_AUTOPILOT_INVALID,
+            type=m.MAV_TYPE_GCS,
+        )
+        assert list(mk.map_heartbeat(impostor, TS)) == []
 
     def test_armed_bool(self):
         out = dict(

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -14,7 +14,6 @@ from conftest import mavlink2keelson as mk
 
 import keelson
 from keelson.payloads.Decomposed3DVector_pb2 import Decomposed3DVector
-from keelson.payloads.EntityHealth_pb2 import EntityHealth, HealthLevel
 from keelson.payloads.Primitives_pb2 import (
     TimestampedBool,
     TimestampedFloat,
@@ -60,18 +59,18 @@ def _build_heartbeat(
 
 
 class TestHeartbeat:
-    def test_emits_three_subjects(self):
+    def test_emits_two_subjects(self):
         out = list(mk.map_heartbeat(_build_heartbeat(), TS))
         subjects = [s for s, _, _ in out]
-        assert subjects == ["vehicle_mode", "vehicle_armed", "entity_health"]
+        assert subjects == ["vehicle_mode", "vehicle_armed"]
 
     def test_non_autopilot_heartbeat_is_dropped(self):
         # A GCS / companion / gimbal sharing the system id sets
         # autopilot=MAV_AUTOPILOT_INVALID. Its HEARTBEAT must NOT drive
-        # vehicle_mode / vehicle_armed / entity_health — otherwise those
-        # subjects flip-flop every second between the real autopilot and the
-        # impostor (the "double heartbeat" bug). It carries the armed bit but a
-        # bogus custom_mode, mirroring the observed Mode(0x80)/armed stream.
+        # vehicle_mode / vehicle_armed — otherwise those subjects flip-flop
+        # every second between the real autopilot and the impostor (the "double
+        # heartbeat" bug). It carries the armed bit but a bogus custom_mode,
+        # mirroring the observed Mode(0x80)/armed stream.
         impostor = _build_heartbeat(
             armed=True,
             custom_mode=0,
@@ -93,36 +92,6 @@ class TestHeartbeat:
         )
         _, armed = _decode(out["vehicle_armed"], TimestampedBool)
         assert armed.value is False
-
-    def test_active_state_maps_to_nominal(self):
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_heartbeat(
-                _build_heartbeat(mode=m.MAV_STATE_ACTIVE), TS
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        assert eh.level == HealthLevel.HEALTH_NOMINAL
-
-    def test_critical_state_maps_to_critical(self):
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_heartbeat(
-                _build_heartbeat(mode=m.MAV_STATE_CRITICAL), TS
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        assert eh.level == HealthLevel.HEALTH_CRITICAL
-
-    def test_emergency_state_maps_to_critical(self):
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_heartbeat(
-                _build_heartbeat(mode=m.MAV_STATE_EMERGENCY), TS
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        assert eh.level == HealthLevel.HEALTH_CRITICAL
 
     def test_envelope_carries_timestamp(self):
         out = list(mk.map_heartbeat(_build_heartbeat(), TS))
@@ -163,77 +132,6 @@ def _build_sys_status(enabled_bits=0, healthy_bits=0, present_bits=None):
 
 
 class TestSysStatus:
-    def test_emits_entity_health(self):
-        out = list(
-            mk.map_sys_status(
-                _build_sys_status(
-                    enabled_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
-                    healthy_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
-                ),
-                TS,
-            )
-        )
-        assert [s for s, _, _ in out] == ["entity_health"]
-
-    def test_nominal_when_all_enabled_bits_healthy(self):
-        bits = (
-            m.MAV_SYS_STATUS_SENSOR_3D_GYRO
-            | m.MAV_SYS_STATUS_SENSOR_3D_ACCEL
-            | m.MAV_SYS_STATUS_SENSOR_3D_MAG
-        )
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_sys_status(
-                _build_sys_status(enabled_bits=bits, healthy_bits=bits), TS
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        assert eh.level == HealthLevel.HEALTH_NOMINAL
-        assert len(eh.sources) == 1
-        source = eh.sources[0]
-        assert source.name == "onboard_sensors"
-        assert source.level == HealthLevel.HEALTH_NOMINAL
-        assert len(source.subjects) == 1
-        subject = source.subjects[0]
-        assert subject.level == HealthLevel.HEALTH_NOMINAL
-        check_names = {c.name for c in subject.checks}
-        assert check_names == {"3d_gyro", "3d_accel", "3d_mag"}
-        assert all(c.level == HealthLevel.HEALTH_NOMINAL for c in subject.checks)
-
-    def test_degraded_when_enabled_bit_unhealthy(self):
-        enabled = m.MAV_SYS_STATUS_SENSOR_3D_GYRO | m.MAV_SYS_STATUS_SENSOR_3D_ACCEL
-        healthy = m.MAV_SYS_STATUS_SENSOR_3D_GYRO  # accel enabled but unhealthy
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_sys_status(
-                _build_sys_status(enabled_bits=enabled, healthy_bits=healthy), TS
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        assert eh.level == HealthLevel.HEALTH_DEGRADED
-        subject = eh.sources[0].subjects[0]
-        assert subject.level == HealthLevel.HEALTH_DEGRADED
-        by_name = {c.name: c for c in subject.checks}
-        assert by_name["3d_gyro"].level == HealthLevel.HEALTH_NOMINAL
-        assert by_name["3d_accel"].level == HealthLevel.HEALTH_DEGRADED
-
-    def test_disabled_bits_are_skipped(self):
-        # 3D_GYRO enabled and healthy; 3D_ACCEL not enabled (must not appear
-        # as a check even though its healthy bit is also unset).
-        out = dict(
-            (s, env)
-            for s, _, env in mk.map_sys_status(
-                _build_sys_status(
-                    enabled_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
-                    healthy_bits=m.MAV_SYS_STATUS_SENSOR_3D_GYRO,
-                ),
-                TS,
-            )
-        )
-        _, eh = _decode(out["entity_health"], EntityHealth)
-        check_names = {c.name for c in eh.sources[0].subjects[0].checks}
-        assert check_names == {"3d_gyro"}
-
     def test_no_fence_enabled_subject_when_geofence_absent(self):
         # A vehicle with no geofence subsystem present must not emit
         # fence_enabled at all (consumers read its absence as "no fence").

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -23,6 +23,7 @@ from keelson.payloads.Primitives_pb2 import (
 )
 from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
+from keelson.payloads.SensorStatus_pb2 import SensorStatus
 
 
 TS = 1_700_000_000_000_000_000  # fixed nanosecond timestamp for determinism
@@ -179,6 +180,71 @@ class TestSysStatus:
         )
         _, fence = _decode(out["fence_enabled"], TimestampedBool)
         assert fence.value is False
+
+
+def _sensor_modes(out):
+    """Collect {source_id_suffix: SensorStatus.mode} from a sys_status mapping.
+
+    sensor_status is fanned out by suffix, so (unlike fence_enabled) it can't be
+    keyed by subject name — several entries share the subject `sensor_status`.
+    """
+    modes = {}
+    for subject, suffix, env in out:
+        if subject == "sensor_status":
+            _, ss = _decode(env, SensorStatus)
+            modes[suffix] = ss.mode
+    return modes
+
+
+class TestSensorStatus:
+    def test_running_when_present_enabled_healthy(self):
+        bit = m.MAV_SYS_STATUS_SENSOR_GPS
+        out = list(
+            mk.map_sys_status(_build_sys_status(enabled_bits=bit, healthy_bits=bit), TS)
+        )
+        modes = _sensor_modes(out)
+        assert modes["/gps"] == SensorStatus.RUNNING
+
+    def test_error_when_enabled_but_unhealthy(self):
+        bit = m.MAV_SYS_STATUS_SENSOR_GPS
+        out = list(
+            mk.map_sys_status(_build_sys_status(enabled_bits=bit, healthy_bits=0), TS)
+        )
+        assert _sensor_modes(out)["/gps"] == SensorStatus.ERROR
+
+    def test_standby_when_present_but_not_enabled(self):
+        # Present but neither enabled nor healthy -> STANDBY (configured-off),
+        # not ERROR.
+        bit = m.MAV_SYS_STATUS_SENSOR_GPS
+        out = list(
+            mk.map_sys_status(
+                _build_sys_status(enabled_bits=0, healthy_bits=0, present_bits=bit),
+                TS,
+            )
+        )
+        assert _sensor_modes(out)["/gps"] == SensorStatus.STANDBY
+
+    def test_absent_when_not_present(self):
+        # A subsystem the vehicle lacks emits no sensor_status at all.
+        out = list(
+            mk.map_sys_status(_build_sys_status(enabled_bits=0, healthy_bits=0), TS)
+        )
+        assert "/gps" not in _sensor_modes(out)
+
+    def test_suffix_naming_for_each_sensor(self):
+        # Every curated bit maps to its readable source_id suffix.
+        bits = 0
+        for _suffix, bit in mk.SENSOR_STATUS_BITS:
+            bits |= bit
+        out = list(
+            mk.map_sys_status(
+                _build_sys_status(enabled_bits=bits, healthy_bits=bits), TS
+            )
+        )
+        modes = _sensor_modes(out)
+        expected = {f"/{suffix}" for suffix, _ in mk.SENSOR_STATUS_BITS}
+        assert set(modes) == expected
+        assert all(v == SensorStatus.RUNNING for v in modes.values())
 
 
 # ---------------------------------------------------------------------------

--- a/connectors/mavlink/tests/test_mavlink_mapping.py
+++ b/connectors/mavlink/tests/test_mavlink_mapping.py
@@ -24,6 +24,7 @@ from keelson.payloads.Primitives_pb2 import (
 from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
 from keelson.payloads.LocationFixQuality_pb2 import LocationFixQuality
 from keelson.payloads.SensorStatus_pb2 import SensorStatus
+from keelson.payloads.VehicleState_pb2 import VehicleState
 
 
 TS = 1_700_000_000_000_000_000  # fixed nanosecond timestamp for determinism
@@ -60,18 +61,18 @@ def _build_heartbeat(
 
 
 class TestHeartbeat:
-    def test_emits_two_subjects(self):
+    def test_emits_three_subjects(self):
         out = list(mk.map_heartbeat(_build_heartbeat(), TS))
         subjects = [s for s, _, _ in out]
-        assert subjects == ["vehicle_mode", "vehicle_armed"]
+        assert subjects == ["vehicle_mode", "vehicle_armed", "vehicle_state"]
 
     def test_non_autopilot_heartbeat_is_dropped(self):
         # A GCS / companion / gimbal sharing the system id sets
         # autopilot=MAV_AUTOPILOT_INVALID. Its HEARTBEAT must NOT drive
-        # vehicle_mode / vehicle_armed — otherwise those subjects flip-flop
-        # every second between the real autopilot and the impostor (the "double
-        # heartbeat" bug). It carries the armed bit but a bogus custom_mode,
-        # mirroring the observed Mode(0x80)/armed stream.
+        # vehicle_mode / vehicle_armed / vehicle_state — otherwise those subjects
+        # flip-flop every second between the real autopilot and the impostor (the
+        # "double heartbeat" bug). It carries the armed bit but a bogus
+        # custom_mode, mirroring the observed Mode(0x80)/armed stream.
         impostor = _build_heartbeat(
             armed=True,
             custom_mode=0,
@@ -93,6 +94,24 @@ class TestHeartbeat:
         )
         _, armed = _decode(out["vehicle_armed"], TimestampedBool)
         assert armed.value is False
+
+    @pytest.mark.parametrize(
+        "mav_state, expected",
+        [
+            (m.MAV_STATE_STANDBY, VehicleState.STATE_STANDBY),
+            (m.MAV_STATE_ACTIVE, VehicleState.STATE_ACTIVE),
+            (m.MAV_STATE_CRITICAL, VehicleState.STATE_CRITICAL),
+            (m.MAV_STATE_EMERGENCY, VehicleState.STATE_EMERGENCY),
+            (m.MAV_STATE_FLIGHT_TERMINATION, VehicleState.STATE_TERMINATED),
+        ],
+    )
+    def test_vehicle_state_maps_mav_state(self, mav_state, expected):
+        out = dict(
+            (s, env)
+            for s, _, env in mk.map_heartbeat(_build_heartbeat(mode=mav_state), TS)
+        )
+        _, vs = _decode(out["vehicle_state"], VehicleState)
+        assert vs.state == expected
 
     def test_envelope_carries_timestamp(self):
         out = list(mk.map_heartbeat(_build_heartbeat(), TS))

--- a/messages/payloads/VehicleState.proto
+++ b/messages/payloads/VehicleState.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+package keelson;
+
+
+message VehicleState {
+
+    // Vehicle-agnostic operational lifecycle / severity state. Maps 1:1 from
+    // MAVLink HEARTBEAT MAV_STATE, but the values are universal operational
+    // concepts (not a MAVLink-specific shape): any vehicle connector can
+    // publish this. The severity tail (CRITICAL / EMERGENCY / TERMINATED) is
+    // the failsafe axis that per-sensor health (sensor_status) cannot express.
+    enum State {
+        STATE_UNKNOWN = 0;      // boot/uninitialised or indeterminate
+        STATE_BOOTING = 1;
+        STATE_CALIBRATING = 2;
+        STATE_STANDBY = 3;      // ready, not active
+        STATE_ACTIVE = 4;       // armed / operating normally
+        STATE_CRITICAL = 5;     // non-normal but still controllable
+        STATE_EMERGENCY = 6;    // mayday
+        STATE_SHUTDOWN = 7;     // powering off
+        STATE_TERMINATED = 8;   // flight/operation terminated
+    }
+
+    // The source timestamp of the state report
+    google.protobuf.Timestamp timestamp = 1;
+
+    State state = 2;
+
+}

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -20,6 +20,7 @@ entity_health:                          keelson.EntityHealth
 # Vehicle state (autopilot-driven)
 vehicle_mode:                           keelson.TimestampedString  # ArduPilot/PX4 mode name (MANUAL, GUIDED, HOLD, AUTO, ...)
 vehicle_armed:                          keelson.TimestampedBool
+vehicle_state:                          keelson.VehicleState       # Operational lifecycle/severity (MAVLink HEARTBEAT MAV_STATE)
 navigation_target:                      foxglove.LocationFix       # Autopilot-reported active nav target, lat/lon (MAVLink POSITION_TARGET_GLOBAL_INT)
 fence_enabled:                          keelson.TimestampedBool    # Geofence enforcement active (MAVLink SYS_STATUS geofence bit)
 


### PR DESCRIPTION
Fix double-heartbeat flip-flop; move health to raw subjects

  The mavlink connector published entity_health from two HEARTBEAT/SYS_STATUS mappers onto the same key with
  disagreeing payloads, so it (and vehicle_mode/vehicle_armed) flip-flopped at ~1 Hz when more than one component
  shared a system id. 

  - Guard vehicle_mode/vehicle_armed to the autopilot — drop HEARTBEATs with autopilot == MAV_AUTOPILOT_INVALID
  (GCS/companion/gimbal).
  - Stop publishing entity_health — computing EntityHealth is the entity_health connector's job; the mavlink connector
  now publishes raw health data instead.
  - sensor_status — per-subsystem health from SYS_STATUS, fanned out by source_id suffix (gps, compass, gyroscope, …);
  present/enabled/health → RUNNING/ERROR/STANDBY.
  - vehicle_state — new typed keelson.VehicleState enum carrying MAV_STATE (the failsafe/severity axis sensors can't
  express).
  
  Tests + docs updated; covered end-to-end by tlog-replay and SITL e2e.
  
  ⚠️  Adds a proto (VehicleState) — run generate_python.sh/generate_javascript.sh after pulling.