### PR TITLE
Reject set_control_mapping on SYSID_MYGCS mismatch

### DIFF
--- a/connectors/mavlink/bin/mavlink2keelson.py
+++ b/connectors/mavlink/bin/mavlink2keelson.py
@@ -3737,6 +3737,43 @@ def _handle_enable_geofence(mav, args, op: RpcOp, target_component: int) -> None
 # ---- VehicleControl: live reconfiguration of manual_control axes ----
 
 
+def _confirmed_sysid_mygcs_mismatch(
+    mav, args: argparse.Namespace, target_component: int
+) -> Optional[int]:
+    """Live re-read of ``SYSID_MYGCS`` for the set_control_mapping guard.
+
+    Returns the autopilot's ``SYSID_MYGCS`` when it reports the param AND it
+    differs from ``--source-system`` — a *confirmed* GCS-authority mismatch,
+    meaning ArduPilot will silently drop this connector's
+    ``RC_CHANNELS_OVERRIDE`` so the mapping cannot drive the vehicle.
+
+    Returns ``None`` for every "cannot confirm a problem" case: ``tlog:``
+    replay (no live autopilot to query), an autopilot that doesn't expose
+    ``SYSID_MYGCS`` (PX4, or a dropped ``PARAM_VALUE`` on a lossy link), or a
+    value that matches. The mapping is allowed through in all of those.
+
+    Re-read live (not cached from the startup check) so an operator who fixes
+    ``SYSID_MYGCS`` on the autopilot after boot isn't rejected on stale data —
+    and vice versa. Cheap to do here: set_control_mapping is a rare operator
+    action, not a hot path, and _read_params uses the recv-thread-safe
+    subscribe() path."""
+    if args.mavlink_url.startswith("tlog:"):
+        return None
+    params = _read_params(
+        mav,
+        args.target_system,
+        _autopilot_component(target_component),
+        ("SYSID_MYGCS",),
+        timeout=5.0,
+    )
+    if "SYSID_MYGCS" not in params:
+        return None
+    sysid_mygcs = int(params["SYSID_MYGCS"])
+    if sysid_mygcs == args.source_system:
+        return None
+    return sysid_mygcs
+
+
 def _handle_set_control_mapping(
     mav,
     args,
@@ -3745,6 +3782,22 @@ def _handle_set_control_mapping(
 ) -> None:
     req = ControlAxisMapping()
     req.ParseFromString(op.request_bytes)
+    # GCS-authority guard: a mapping is worthless if ArduPilot will silently
+    # drop our RC_CHANNELS_OVERRIDE. Re-read SYSID_MYGCS live and refuse on a
+    # confirmed mismatch rather than ack a mapping that can't drive the
+    # vehicle. PX4 / tlog / unreadable param -> not confirmed -> allow.
+    sysid_mygcs = _confirmed_sysid_mygcs_mismatch(mav, args, target_component)
+    if sysid_mygcs is not None:
+        _reply_err(
+            op.query,
+            f"set_control_mapping: --source-system {args.source_system} does "
+            f"not match the autopilot's SYSID_MYGCS {sysid_mygcs}; ArduPilot "
+            f"will silently drop RC_CHANNELS_OVERRIDE, so this mapping would "
+            f"not drive the vehicle. Restart with --source-system "
+            f"{sysid_mygcs} (or set SYSID_MYGCS={args.source_system} on the "
+            f"autopilot).",
+        )
+        return
     control_axis_state = args._control_axis_state
     try:
         control_axis_state.set_mapping(req)

--- a/connectors/mavlink/tests/test_mavlink_rpcs.py
+++ b/connectors/mavlink/tests/test_mavlink_rpcs.py
@@ -977,9 +977,22 @@ class TestControlAxisState:
 
 
 class TestControlAxisMappingRpcs:
-    def test_set_mapping_calls_state(self):
+    @staticmethod
+    def _args(state, source_system=255, mavlink_url="udpin:0.0.0.0:14550"):
+        return argparse.Namespace(
+            _control_axis_state=state,
+            mavlink_url=mavlink_url,
+            target_system=1,
+            source_system=source_system,
+        )
+
+    def test_set_mapping_calls_state(self, monkeypatch):
+        # SYSID_MYGCS matches --source-system -> guard passes, mapping applies.
+        monkeypatch.setattr(
+            mavlink2keelson, "_read_params", lambda *a, **kw: {"SYSID_MYGCS": 255.0}
+        )
         state = MagicMock()
-        args = argparse.Namespace(_control_axis_state=state)
+        args = self._args(state, source_system=255)
         req = ControlAxisMapping(
             axes={
                 "steering": ControlAxis(subject="joystick_x_pct", source_id="js-1"),
@@ -994,16 +1007,64 @@ class TestControlAxisMappingRpcs:
         op.query.reply.assert_called_once()
         ControlAxisMappingAck().ParseFromString(op.query.reply.call_args.args[1])
 
-    def test_set_mapping_value_error_returns_error_response(self):
+    def test_set_mapping_value_error_returns_error_response(self, monkeypatch):
+        monkeypatch.setattr(
+            mavlink2keelson, "_read_params", lambda *a, **kw: {"SYSID_MYGCS": 255.0}
+        )
         state = MagicMock()
         state.set_mapping.side_effect = ValueError("unknown axis 'ailerons'")
-        args = argparse.Namespace(_control_axis_state=state)
+        args = self._args(state, source_system=255)
         op = _make_op(ControlAxisMapping(), "set_control_mapping")
         mavlink2keelson._handle_set_control_mapping(MagicMock(), args, op, 0)
 
         assert not op.query.reply.called
         err = _decoded_err(op.query)
         assert "ailerons" in err
+
+    def test_set_mapping_rejects_on_sysid_mismatch(self, monkeypatch):
+        # Autopilot reports SYSID_MYGCS 254 but we heartbeat as 255: ArduPilot
+        # would silently drop our overrides, so the mapping is refused and
+        # never installed.
+        monkeypatch.setattr(
+            mavlink2keelson, "_read_params", lambda *a, **kw: {"SYSID_MYGCS": 254.0}
+        )
+        state = MagicMock()
+        args = self._args(state, source_system=255)
+        op = _make_op(ControlAxisMapping(), "set_control_mapping")
+        mavlink2keelson._handle_set_control_mapping(MagicMock(), args, op, 0)
+
+        assert not state.set_mapping.called
+        assert not op.query.reply.called
+        err = _decoded_err(op.query)
+        assert "SYSID_MYGCS 254" in err
+        assert "--source-system 255" in err
+
+    def test_set_mapping_allows_when_sysid_absent(self, monkeypatch):
+        # PX4 (no SYSID_MYGCS) or a dropped PARAM_VALUE -> cannot confirm a
+        # problem -> the mapping is applied rather than spuriously refused.
+        monkeypatch.setattr(mavlink2keelson, "_read_params", lambda *a, **kw: {})
+        state = MagicMock()
+        args = self._args(state, source_system=255)
+        op = _make_op(ControlAxisMapping(), "set_control_mapping")
+        mavlink2keelson._handle_set_control_mapping(MagicMock(), args, op, 0)
+
+        state.set_mapping.assert_called_once()
+        op.query.reply.assert_called_once()
+
+    def test_set_mapping_skips_sysid_read_for_tlog(self, monkeypatch):
+        # tlog replay has no live autopilot to query — never hit the wire.
+        called = []
+        monkeypatch.setattr(
+            mavlink2keelson, "_read_params", lambda *a, **kw: called.append(1) or {}
+        )
+        state = MagicMock()
+        args = self._args(state, source_system=255, mavlink_url="tlog:flight.tlog")
+        op = _make_op(ControlAxisMapping(), "set_control_mapping")
+        mavlink2keelson._handle_set_control_mapping(MagicMock(), args, op, 0)
+
+        assert called == []
+        state.set_mapping.assert_called_once()
+        op.query.reply.assert_called_once()
 
     def test_get_mapping_returns_state(self):
         state = MagicMock()


### PR DESCRIPTION
A control mapping is worthless if ArduPilot will silently drop the connector's RC_CHANNELS_OVERRIDE — which it does whenever --source-system does not match the autopilot's SYSID_MYGCS. Acking such a mapping is the exact "looks wired up but does nothing" trap the startup warning flags.

Guard set_control_mapping with a live re-read of SYSID_MYGCS and reply_err on a confirmed mismatch, so the failure surfaces at the call site with an actionable message instead of a dead joystick. Re-read (not cached from startup) so fixing SYSID_MYGCS after boot isn't rejected on stale data. Only a confirmed mismatch rejects: tlog replay, PX4 (no SYSID_MYGCS), and a dropped PARAM_VALUE all fall through to "allow". The startup warning is left in place as the early log signal.