### PR TITLE
feat(sim): add SimulationControl + VehicleSimulatorControl interfaces

### DIFF
--- a/interfaces/SimulationControl.proto
+++ b/interfaces/SimulationControl.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+// RPC interface for the real-time lifecycle of a simulated entity:
+// start, pause, and stop. The contract is deliberately domain-agnostic —
+// it names nothing vehicle-specific, so a vehicle simulator, an engine
+// simulator, or an environment simulator can all implement it verbatim.
+// Domain-specific setup (e.g. a vehicle's initial pose) lives in a
+// separate companion interface such as VehicleSimulatorControl.
+//
+// Scope is per-entity: each simulated entity serves this interface under
+// its OWN entity_id (e.g.
+// {base}/@v0/boat1/@rpc/SimulationControl/start/{responder}), exactly as
+// a real connector like mavlink2keelson serves its entity. There is no
+// central "simulator" entity and no dynamic identity — the set of
+// entity_ids is configuration, known up front, so downstream connectors
+// can bind to them ahead of time.
+//
+// Time model (real-time v1): the simulator runs at wall-clock rate, so
+// sim-time == wall-time and there is no clock to distribute. A paused
+// entity simply stops publishing and resumes from its frozen state at the
+// current wall-clock — the only visible effect is a gap in the data,
+// which is honest. Faster- or slower-than-real-time scenario control is
+// deliberately out of scope; if it is ever added it arrives as a separate
+// world-level interface on a scenario entity, leaving this per-entity
+// lifecycle contract unchanged.
+//
+// State machine (broadcast continuously as the keelson.SimulationStatus
+// pub/sub payload — clients observe state by subscribing, not by an RPC):
+//
+//     STOPPED ──start──► RUNNING ──pause──► PAUSED
+//        ▲                  │                  │
+//        └──── stop ◄───────┴──────start───────┘
+//
+//   start : STOPPED | ASSIGNED | PAUSED -> RUNNING
+//           begin, or resume, advancing the entity.
+//   pause : RUNNING                     -> PAUSED
+//           freeze in place; data gaps until the next start.
+//   stop  : any                         -> STOPPED
+//           halt and reset to the configured / last-set initial pose.
+//
+// Calling an RPC in a state where it has no meaning (e.g. pause while
+// STOPPED) replies with ErrorResponse{code = INVALID_STATE}.
+//
+// NOTE: this interface defines the contract only. A connector must still
+// implement the server side; until then, no service is guaranteed to be
+// reachable.
+
+// One response message per RPC, empty for now. Each is dedicated to its
+// method so an individual command can grow a return field later (e.g.
+// start/pause returning the authoritative sim-time at the transition)
+// without a breaking type change and without that field bleeding onto the
+// other commands.
+message StartResponse {}
+message PauseResponse {}
+message StopResponse {}
+
+service SimulationControl {
+  rpc start(google.protobuf.Empty) returns (StartResponse);
+  rpc pause(google.protobuf.Empty) returns (PauseResponse);
+  rpc stop(google.protobuf.Empty)  returns (StopResponse);
+}

--- a/interfaces/VehicleSimulatorControl.proto
+++ b/interfaces/VehicleSimulatorControl.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+import "VehicleCommon.proto";
+
+// RPC interface for the vehicle-specific setup of a simulated vehicle:
+// placing it at an initial pose before (or between) runs. This is the
+// vehicle-shaped companion to the domain-agnostic SimulationControl
+// (start/pause/stop). It is kept separate precisely because an initial
+// pose — WGS84 position, heading, speed over ground — is meaningful only
+// for a vehicle; an engine or environment simulator would expose its own
+// typed setup interface while sharing SimulationControl verbatim.
+//
+// Scope mirrors SimulationControl: served per-entity under the simulated
+// vehicle's OWN entity_id (e.g.
+// {base}/@v0/boat1/@rpc/VehicleSimulatorControl/set_initial_pose/{responder}).
+// The entity_id is static configuration; this interface does NOT create
+// or destroy entities (there is no spawn/despawn) — it only positions one
+// that already exists. Keeping identity static means downstream
+// connectors that consume the simulated data can be configured against
+// the entity_ids ahead of time. Dynamic entity creation, if ever needed,
+// is a separate additive interface and does not change this contract.
+//
+// set_initial_pose is valid while the entity is STOPPED or ASSIGNED (not
+// yet running); it (re)places the entity and moves it to the ASSIGNED
+// state, ready for SimulationControl.start. Calling it on a RUNNING or
+// PAUSED entity replies with ErrorResponse{code = INVALID_STATE}.
+//
+// NOTE: this interface defines the contract only. A connector must still
+// implement the server side; until then, no service is guaranteed to be
+// reachable.
+
+message InitialPose {
+  // WGS84 start position, reusing the shared Vehicle* coordinate shape.
+  Coordinate position = 1;
+
+  // Initial heading in degrees, true north, expected range [0, 360).
+  double heading_deg = 2;
+
+  // Initial speed over ground in metres per second; 0 = at rest.
+  double sog_mps = 3;
+}
+
+// Dedicated response message so set_initial_pose can grow a return field
+// later (e.g. the resolved/clamped pose) without a breaking type change.
+message SetInitialPoseResponse {}
+
+service VehicleSimulatorControl {
+  // (Re)place a statically-declared entity at an initial pose while it is
+  // STOPPED/ASSIGNED.
+  rpc set_initial_pose(InitialPose) returns (SetInitialPoseResponse);
+}

--- a/messages/payloads/SimulationStatus.proto
+++ b/messages/payloads/SimulationStatus.proto
@@ -27,5 +27,5 @@ message SimulationStatus {
   string id = 4;
   
   // The simulation timestamp
-  google.protobuf.Timestamp timestampSimulation = 5;  
+  google.protobuf.Timestamp simulation_timestamp = 5;
 }

--- a/messages/payloads/SimulationStatus.proto
+++ b/messages/payloads/SimulationStatus.proto
@@ -12,9 +12,8 @@ message SimulationStatus {
   enum SimulationState {
     UNKNOWN = 0;
     STOPPED = 1;
-    ASSIGNED = 2;
-    RUNNING = 3;
-    PAUSED = 4;
+    RUNNING = 2;
+    PAUSED = 3;
   }
 
   // The current state of the simulation


### PR DESCRIPTION
Real-time v1 of the simulation control surface, split by axis:

- SimulationControl: domain-agnostic lifecycle (start/pause/stop), served per-entity on the simulated entity's own id. Per-RPC empty response messages so each command can grow return fields without a breaking type change. State machine + INVALID_STATE error contract documented inline.
- VehicleSimulatorControl: vehicle-specific set_initial_pose(InitialPose), placing a statically-declared entity. No spawn/despawn — identity is static config so downstream connectors can bind to entity_ids up front.

Entity creation (dynamic spawn) and faster-than-real-time scenario control are deliberately out of scope; both are additive future interfaces that leave this contract unchanged.

Also fix the lone camelCase field in SimulationStatus (timestampSimulation -> simulation_timestamp; wire tag unchanged).

Namespace/collision concerns for interface wrappers tracked in #159.