### PR TITLE
tak: fix rx_queue regression + configure connection from a TAK data package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ tmp/
 
 # TAK data packages (contain client keys + plaintext passwords)
 atak.zip
+itak.zip
+*tak-data-package*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ tmp/
 # AI
 .claude
 .devcontainer/devcontainer-lock.json
+
+# TAK data packages (contain client keys + plaintext passwords)
+atak.zip

--- a/connectors/tak/README.md
+++ b/connectors/tak/README.md
@@ -5,7 +5,9 @@ Bi-directional bridge between a TAK / CoT server (e.g. [taky](https://github.com
 * `keelson2tak` — reads keelson subjects describing the local entity (position, course, speed, name) and emits CoT XML events to a TAK server over TCP or TLS.
 * `tak2keelson` — subscribes to a TAK server, parses inbound CoT events, and republishes them as keelson `@target/cot_{uid}` subjects (same pattern as `ais2keelson`'s `@target/mmsi_{mmsi}`).
 
-Only the XML CoT wire format is supported. The protobuf "TAK Protocol v1" (mesh/stream), UDP multicast mesh mode, GeoChat, and data-package attachments are out of scope.
+Only the XML CoT wire format is supported. The protobuf "TAK Protocol v1" (mesh/stream), UDP multicast mesh mode, GeoChat, and CoT data-package *attachments* (mission packages sent over the wire) are out of scope.
+
+> **Connection config from a TAK data/pref package.** A *pref package* — the `atak.zip` a TAK admin hands out for client enrollment — bundles the server `connectString` plus the client/CA certificates. Both binaries accept it via `--tak-data-package` as an alternative to the explicit `--tak-url` + `--tak-client-cert/--tak-client-key/--tak-ca` flags; pytak unzips it, reads the `.pref`, and converts the PKCS#12 keystore to PEM. The package contains a private key and keystore passwords — keep it out of version control (`atak.zip` is gitignored).
 
 ## Subject mapping
 
@@ -49,7 +51,8 @@ Every event also carries `event/@uid`, `@type`, `@how`, `@time`, `@start`, `@sta
 ```
 usage: tak2keelson [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
                    [--connect CONNECT] -r REALM -e ENTITY_ID -s SOURCE_ID
-                   --tak-url TAK_URL [--tak-client-cert TAK_CLIENT_CERT]
+                   (--tak-url TAK_URL | --tak-data-package TAK_DATA_PACKAGE)
+                   [--tak-client-cert TAK_CLIENT_CERT]
                    [--tak-client-key TAK_CLIENT_KEY] [--tak-ca TAK_CA]
                    [--tak-insecure] [--reconnect-delay RECONNECT_DELAY]
                    [--publish-raw] [--target-timeout-s TARGET_TIMEOUT_S]
@@ -60,7 +63,8 @@ usage: tak2keelson [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
 ```
 usage: keelson2tak [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
                    [--connect CONNECT] -r REALM -e ENTITY_ID
-                   --tak-url TAK_URL [--tak-client-cert TAK_CLIENT_CERT]
+                   (--tak-url TAK_URL | --tak-data-package TAK_DATA_PACKAGE)
+                   [--tak-client-cert TAK_CLIENT_CERT]
                    [--tak-client-key TAK_CLIENT_KEY] [--tak-ca TAK_CA]
                    [--tak-insecure] [--reconnect-delay RECONNECT_DELAY]
                    --cot-uid COT_UID [--cot-type COT_TYPE]
@@ -93,6 +97,15 @@ keelson2tak \
   --tak-client-cert /etc/keelson/tak-client.pem \
   --tak-client-key /etc/keelson/tak-client.key \
   --tak-ca /etc/keelson/tak-ca.pem \
+  --cot-uid rise-landkrabban-self
+```
+
+From a TAK data package (server URL + certs come from the package):
+
+```bash
+keelson2tak \
+  --realm rise --entity-id landkrabban \
+  --tak-data-package /etc/keelson/atak.zip \
   --cot-uid rise-landkrabban-self
 ```
 

--- a/connectors/tak/bin/keelson2tak.py
+++ b/connectors/tak/bin/keelson2tak.py
@@ -171,25 +171,46 @@ def _emit_cot() -> None:
 
 
 def _build_pytak_config(args: argparse.Namespace) -> ConfigParser:
-    """Translate our CLI flags into a pytak-style ConfigParser section."""
     cp = ConfigParser()
-    section = {"COT_URL": args.tak_url}
-    parsed = urllib.parse.urlparse(args.tak_url)
-    if parsed.scheme.startswith("tls") or parsed.scheme == "ssl":
-        if args.tak_client_cert:
-            section["PYTAK_TLS_CLIENT_CERT"] = args.tak_client_cert
-        if args.tak_client_key:
-            section["PYTAK_TLS_CLIENT_KEY"] = args.tak_client_key
-        if args.tak_ca:
-            section["PYTAK_TLS_CLIENT_CAFILE"] = args.tak_ca
-        if args.tak_insecure:
-            section["PYTAK_TLS_DONT_VERIFY"] = "1"
-            section["PYTAK_TLS_DONT_CHECK_HOSTNAME"] = "1"
-            logger.warning(
-                "--tak-insecure: skipping TLS hostname and certificate verification"
-            )
-    cp["keelson2tak"] = section
+    cp["keelson2tak"] = _build_pytak_section(args)
     return cp
+
+
+def _build_pytak_section(args: argparse.Namespace) -> dict:
+    """Translate our CLI flags into a pytak config section.
+
+    Connection material comes from either an explicit --tak-url (+ optional
+    cert/key/ca) or a TAK data/pref package. For a package, pytak unzips it,
+    reads its *.pref (connectString + certificate references) and converts the
+    bundled PKCS#12 keystore to PEM, yielding COT_URL + TLS cert/key/CA paths.
+    The package holds a private key and passwords — never log the section.
+    """
+    if args.tak_data_package:
+        section = {
+            k: v for k, v in pytak.read_pref_package(args.tak_data_package).items() if v
+        }
+        if args.tak_client_cert or args.tak_client_key or args.tak_ca:
+            logger.warning(
+                "Ignoring --tak-client-cert/--tak-client-key/--tak-ca: "
+                "the data package provides the TLS material"
+            )
+    else:
+        section = {"COT_URL": args.tak_url}
+        parsed = urllib.parse.urlparse(args.tak_url)
+        if parsed.scheme.startswith("tls") or parsed.scheme == "ssl":
+            if args.tak_client_cert:
+                section["PYTAK_TLS_CLIENT_CERT"] = args.tak_client_cert
+            if args.tak_client_key:
+                section["PYTAK_TLS_CLIENT_KEY"] = args.tak_client_key
+            if args.tak_ca:
+                section["PYTAK_TLS_CLIENT_CAFILE"] = args.tak_ca
+    if args.tak_insecure:
+        section["PYTAK_TLS_DONT_VERIFY"] = "1"
+        section["PYTAK_TLS_DONT_CHECK_HOSTNAME"] = "1"
+        logger.warning(
+            "--tak-insecure: skipping TLS hostname and certificate verification"
+        )
+    return section
 
 
 async def _run_async(args: argparse.Namespace) -> None:
@@ -235,7 +256,15 @@ def main():
     parser.add_argument("--connect", action="append", type=str)
     parser.add_argument("-r", "--realm", type=str, required=True)
     parser.add_argument("-e", "--entity-id", type=str, required=True)
-    parser.add_argument("--tak-url", type=str, required=True)
+    tak_endpoint = parser.add_mutually_exclusive_group(required=True)
+    tak_endpoint.add_argument(
+        "--tak-url", type=str, help="TAK server URL, e.g. tls://host:8089"
+    )
+    tak_endpoint.add_argument(
+        "--tak-data-package",
+        type=str,
+        help="Path to a TAK data/pref package (.zip); provides COT_URL + TLS certs",
+    )
     parser.add_argument("--tak-client-cert", type=str, default=None)
     parser.add_argument("--tak-client-key", type=str, default=None)
     parser.add_argument("--tak-ca", type=str, default=None)

--- a/connectors/tak/bin/tak2keelson.py
+++ b/connectors/tak/bin/tak2keelson.py
@@ -237,7 +237,7 @@ async def _run_async(session: zenoh.Session, args: argparse.Namespace) -> None:
     cp = _build_pytak_config(args)
     clitool = pytak.CLITool(cp["tak2keelson"])
     await clitool.setup()
-    clitool.add_task(_CoTReceiver(clitool.queue, cp["tak2keelson"], session, args))
+    clitool.add_task(_CoTReceiver(clitool.rx_queue, cp["tak2keelson"], session, args))
     await clitool.run()
 
 

--- a/connectors/tak/bin/tak2keelson.py
+++ b/connectors/tak/bin/tak2keelson.py
@@ -154,23 +154,45 @@ def parse_cot_event(
 
 def _build_pytak_config(args: argparse.Namespace) -> ConfigParser:
     cp = ConfigParser()
-    section = {"COT_URL": args.tak_url}
-    parsed = urllib.parse.urlparse(args.tak_url)
-    if parsed.scheme.startswith("tls") or parsed.scheme == "ssl":
-        if args.tak_client_cert:
-            section["PYTAK_TLS_CLIENT_CERT"] = args.tak_client_cert
-        if args.tak_client_key:
-            section["PYTAK_TLS_CLIENT_KEY"] = args.tak_client_key
-        if args.tak_ca:
-            section["PYTAK_TLS_CLIENT_CAFILE"] = args.tak_ca
-        if args.tak_insecure:
-            section["PYTAK_TLS_DONT_VERIFY"] = "1"
-            section["PYTAK_TLS_DONT_CHECK_HOSTNAME"] = "1"
-            logger.warning(
-                "--tak-insecure: skipping TLS hostname and certificate verification"
-            )
-    cp["tak2keelson"] = section
+    cp["tak2keelson"] = _build_pytak_section(args)
     return cp
+
+
+def _build_pytak_section(args: argparse.Namespace) -> dict:
+    """Translate our CLI flags into a pytak config section.
+
+    Connection material comes from either an explicit --tak-url (+ optional
+    cert/key/ca) or a TAK data/pref package. For a package, pytak unzips it,
+    reads its *.pref (connectString + certificate references) and converts the
+    bundled PKCS#12 keystore to PEM, yielding COT_URL + TLS cert/key/CA paths.
+    The package holds a private key and passwords — never log the section.
+    """
+    if args.tak_data_package:
+        section = {
+            k: v for k, v in pytak.read_pref_package(args.tak_data_package).items() if v
+        }
+        if args.tak_client_cert or args.tak_client_key or args.tak_ca:
+            logger.warning(
+                "Ignoring --tak-client-cert/--tak-client-key/--tak-ca: "
+                "the data package provides the TLS material"
+            )
+    else:
+        section = {"COT_URL": args.tak_url}
+        parsed = urllib.parse.urlparse(args.tak_url)
+        if parsed.scheme.startswith("tls") or parsed.scheme == "ssl":
+            if args.tak_client_cert:
+                section["PYTAK_TLS_CLIENT_CERT"] = args.tak_client_cert
+            if args.tak_client_key:
+                section["PYTAK_TLS_CLIENT_KEY"] = args.tak_client_key
+            if args.tak_ca:
+                section["PYTAK_TLS_CLIENT_CAFILE"] = args.tak_ca
+    if args.tak_insecure:
+        section["PYTAK_TLS_DONT_VERIFY"] = "1"
+        section["PYTAK_TLS_DONT_CHECK_HOSTNAME"] = "1"
+        logger.warning(
+            "--tak-insecure: skipping TLS hostname and certificate verification"
+        )
+    return section
 
 
 def _publish_subjects(
@@ -252,7 +274,15 @@ def main():
     parser.add_argument("-r", "--realm", type=str, required=True)
     parser.add_argument("-e", "--entity-id", type=str, required=True)
     parser.add_argument("-s", "--source-id", type=str, required=True)
-    parser.add_argument("--tak-url", type=str, required=True)
+    tak_endpoint = parser.add_mutually_exclusive_group(required=True)
+    tak_endpoint.add_argument(
+        "--tak-url", type=str, help="TAK server URL, e.g. tls://host:8089"
+    )
+    tak_endpoint.add_argument(
+        "--tak-data-package",
+        type=str,
+        help="Path to a TAK data/pref package (.zip); provides COT_URL + TLS certs",
+    )
     parser.add_argument("--tak-client-cert", type=str, default=None)
     parser.add_argument("--tak-client-key", type=str, default=None)
     parser.add_argument("--tak-ca", type=str, default=None)

--- a/connectors/tak/tests/test_tak_data_package.py
+++ b/connectors/tak/tests/test_tak_data_package.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for TAK data/pref package configuration.
+
+These exercise our wiring of pytak.read_pref_package into the connector's
+pytak config section. The package parsing itself (unzip, *.pref, PKCS#12 ->
+PEM) is pytak's responsibility and is mocked here.
+"""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from conftest import tak2keelson, keelson2tak
+
+PKG_RESULT = {
+    "COT_URL": "tls://tak.example.com:8089",
+    "PYTAK_TLS_CLIENT_CERT": "/tmp/dp/cert.pem",
+    "PYTAK_TLS_CLIENT_KEY": "/tmp/dp/key.pem",
+    "PYTAK_TLS_CLIENT_CAFILE": "/tmp/dp/ca.pem",
+}
+
+
+def _args(**overrides):
+    base = dict(
+        tak_url=None,
+        tak_data_package=None,
+        tak_client_cert=None,
+        tak_client_key=None,
+        tak_ca=None,
+        tak_insecure=False,
+    )
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_data_package_populates_tls_section(mod):
+    args = _args(tak_data_package="/path/atak.zip")
+    with patch.object(
+        mod.pytak, "read_pref_package", return_value=dict(PKG_RESULT)
+    ) as m:
+        section = mod._build_pytak_section(args)
+    m.assert_called_once_with("/path/atak.zip")
+    assert section == PKG_RESULT
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_data_package_drops_none_values(mod):
+    # A plain-TCP pref package (no TLS material) -> None entries must be dropped,
+    # since a ConfigParser section only accepts string values.
+    with patch.object(
+        mod.pytak,
+        "read_pref_package",
+        return_value={"COT_URL": "tcp://h:8087", "PYTAK_TLS_CLIENT_CERT": None},
+    ):
+        section = mod._build_pytak_section(_args(tak_data_package="/p.zip"))
+    assert section == {"COT_URL": "tcp://h:8087"}
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_data_package_ignores_explicit_certs(mod):
+    args = _args(tak_data_package="/p.zip", tak_client_cert="/x.pem")
+    with patch.object(mod.pytak, "read_pref_package", return_value=dict(PKG_RESULT)):
+        section = mod._build_pytak_section(args)
+    # The package value wins; the explicit flag is not consulted.
+    assert section["PYTAK_TLS_CLIENT_CERT"] == PKG_RESULT["PYTAK_TLS_CLIENT_CERT"]
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_insecure_applies_with_data_package(mod):
+    args = _args(tak_data_package="/p.zip", tak_insecure=True)
+    with patch.object(mod.pytak, "read_pref_package", return_value=dict(PKG_RESULT)):
+        section = mod._build_pytak_section(args)
+    assert section["PYTAK_TLS_DONT_VERIFY"] == "1"
+    assert section["PYTAK_TLS_DONT_CHECK_HOSTNAME"] == "1"
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_explicit_url_with_tls_flags(mod):
+    args = _args(
+        tak_url="tls://h:8089",
+        tak_client_cert="/c.pem",
+        tak_client_key="/k.pem",
+        tak_ca="/ca.pem",
+    )
+    section = mod._build_pytak_section(args)
+    assert section == {
+        "COT_URL": "tls://h:8089",
+        "PYTAK_TLS_CLIENT_CERT": "/c.pem",
+        "PYTAK_TLS_CLIENT_KEY": "/k.pem",
+        "PYTAK_TLS_CLIENT_CAFILE": "/ca.pem",
+    }
+
+
+@pytest.mark.parametrize("mod", [tak2keelson, keelson2tak])
+def test_explicit_plain_tcp_has_no_tls_keys(mod):
+    section = mod._build_pytak_section(_args(tak_url="tcp://h:8087"))
+    assert section == {"COT_URL": "tcp://h:8087"}

--- a/connectors/tak/tests/test_tak_e2e.py
+++ b/connectors/tak/tests/test_tak_e2e.py
@@ -38,8 +38,11 @@ def test_keelson2tak_help_exits_zero(run_connector):
 class _DummyTakServer:
     """Tiny asyncio TCP listener that records everything each client sends."""
 
-    def __init__(self, port: int):
+    def __init__(self, port: int, send_on_connect: bytes | None = None):
         self.port = port
+        # When set, the server pushes this CoT blob to every connected client
+        # repeatedly (~1 Hz), standing in for a TAK server relaying a track.
+        self.send_on_connect = send_on_connect
         self._loop: asyncio.AbstractEventLoop | None = None
         self._server: asyncio.base_events.Server | None = None
         self._thread: threading.Thread | None = None
@@ -47,6 +50,16 @@ class _DummyTakServer:
         self._ready = threading.Event()
 
     async def _handle(self, reader, writer):
+        async def _pump():
+            try:
+                while True:
+                    writer.write(self.send_on_connect)
+                    await writer.drain()
+                    await asyncio.sleep(1.0)
+            except (asyncio.CancelledError, ConnectionError):
+                pass
+
+        pump_task = asyncio.ensure_future(_pump()) if self.send_on_connect else None
         try:
             while True:
                 data = await reader.read(4096)
@@ -55,6 +68,9 @@ class _DummyTakServer:
                 self.received.append(data)
         except (asyncio.CancelledError, ConnectionError):
             return
+        finally:
+            if pump_task is not None:
+                pump_task.cancel()
 
     def start(self):
         def _run():
@@ -186,5 +202,99 @@ def test_position_roundtrips_to_dummy_tak_server(
         point = root.find("point")
         assert float(point.get("lat")) == pytest.approx(57.706, abs=1e-3)
         assert float(point.get("lon")) == pytest.approx(11.937, abs=1e-3)
+    finally:
+        server.stop()
+
+
+@pytest.mark.e2e
+def test_cot_event_republishes_to_keelson(connector_process_factory, zenoh_endpoints):
+    """tak2keelson should connect to a TAK server, receive a CoT event, and
+    republish the mapped fields as keelson subjects under @target/cot_{uid}.
+
+    Guards two easy-to-miss failure modes: the inbound pytak receive wiring
+    (regression for the CLITool rx_queue hookup) and the subscriber key
+    expression — @v0 and @target are verbatim chunks that ``**`` never matches,
+    so a naive ``realm/**`` subscription silently sees nothing.
+    """
+    import zenoh
+    import keelson
+
+    cot_uid = "DUMMY-PHONE-1"
+    cot_bytes = (
+        '<event version="2.0" uid="%s" type="a-f-G-U-C" how="m-g" '
+        'time="2026-01-01T00:00:00.00Z" start="2026-01-01T00:00:00.00Z" '
+        'stale="2099-01-01T00:00:00.00Z">'
+        '<point lat="57.706" lon="11.937" hae="12.3" ce="4.5" le="9999999.0"/>'
+        '<detail><contact callsign="DUMMYBOAT"/></detail></event>'
+    ) % cot_uid
+    cot_bytes = cot_bytes.encode()
+
+    tak_port = _free_port()
+    server = _DummyTakServer(tak_port, send_on_connect=cot_bytes)
+    server.start()
+
+    received: dict[str, bytes] = {}
+    try:
+        sub_conf = zenoh.Config()
+        sub_conf.insert_json5("mode", '"peer"')
+        sub_conf.insert_json5("listen/endpoints", f'["{zenoh_endpoints["listen"]}"]')
+
+        with zenoh.open(sub_conf) as session:
+
+            def handler(sample):
+                subject = keelson.get_subject_from_pubsub_key(str(sample.key_expr))
+                _r, _e, inner = keelson.uncover(bytes(sample.payload.to_bytes()))
+                received[subject] = inner
+
+            # @v0 and @target are verbatim chunks; spell them out literally.
+            session.declare_subscriber("test-realm/@v0/**/@target/**", handler)
+
+            tak2keelson = connector_process_factory(
+                "tak",
+                "tak2keelson",
+                [
+                    "--realm",
+                    "test-realm",
+                    "--entity-id",
+                    "test-vessel",
+                    "--source-id",
+                    "tak/0",
+                    "--mode",
+                    "peer",
+                    "--connect",
+                    zenoh_endpoints["connect"],
+                    "--tak-url",
+                    f"tcp://127.0.0.1:{tak_port}",
+                ],
+            )
+            tak2keelson.start()
+            time.sleep(4)
+            assert tak2keelson.is_running(), (
+                "tak2keelson exited early. stderr: " f"{tak2keelson.logs()[1][:2000]}"
+            )
+
+            for _ in range(10):
+                if "location_fix" in received:
+                    break
+                time.sleep(0.6)
+
+            tak2keelson.stop()
+
+        assert (
+            "location_fix" in received
+        ), "tak2keelson never published location_fix to the bus."
+
+        from keelson.payloads.foxglove.LocationFix_pb2 import LocationFix
+
+        loc = LocationFix()
+        loc.ParseFromString(received["location_fix"])
+        assert loc.latitude == pytest.approx(57.706, abs=1e-3)
+        assert loc.longitude == pytest.approx(11.937, abs=1e-3)
+
+        assert "name" in received, "callsign was not republished as `name`."
+        name = keelson.decode_protobuf_payload_from_type_name(
+            received["name"], keelson.get_subject_schema("name")
+        )
+        assert name.value == "DUMMYBOAT"
     finally:
         server.stop()


### PR DESCRIPTION
Two related changes to the TAK connector, plus a secrets-hygiene fix.

## 1. Fix: `tak2keelson` rx_queue regression

`tak2keelson` crashed immediately on connect:

```
AttributeError: 'CLITool' object has no attribute 'queue'. Did you mean: 'queues'?
```

It passed `clitool.queue` to its CoT receiver, but pytak 7.3.0 (the pinned version) exposes `rx_queue` / `tx_queue`, not `queue`. The inbound (TAK → keelson) direction was effectively non-functional. Fix: use `clitool.rx_queue` for the inbound receiver (sibling `keelson2tak` already uses `tx_queue`).

**Why it slipped through:** the only e2e coverage for `tak2keelson` was `--help`; the roundtrip test exercised `keelson2tak` (outbound) only.

Adds `test_cot_event_republishes_to_keelson`: the dummy TAK server pushes a CoT track (~1 Hz), the real `tak2keelson` binary republishes it, and we assert `location_fix` + `name` land on the bus. The subscriber uses `test-realm/@v0/**/@target/**` rather than `realm/**` — `@v0`/`@target` are zenoh **verbatim chunks** that wildcards never match, so a naive `realm/**` would silently receive nothing. Reverting the fix makes this test fail on startup.

## 2. Feature: configure the connection from a TAK data/pref package

Add `--tak-data-package` to **both** binaries as an alternative to the explicit `--tak-url` + `--tak-client-cert`/`--tak-client-key`/`--tak-ca` quartet. It's the standard ATAK client-enrollment artifact (`atak.zip`), which bundles exactly the connection material the connector needs.

`pytak.read_pref_package` does the parsing (unzip → `.pref` `connectString`→`COT_URL` + cert references → PKCS#12 keystore→PEM); we merge the result into the pytak config section. Details:

- `--tak-url` and `--tak-data-package` are a **required mutually-exclusive group**.
- `--tak-insecure` still applies; explicit cert flags are ignored (with a warning) when a package is given.
- Per-bin config logic refactored into a testable `_build_pytak_section()`.
- New `test_tak_data_package.py` (12 cases, parametrized over both bins). The `.pref`/p12 parsing is pytak's and is mocked.

This is deployment-static connection config → a CLI flag, per `connectors/CLAUDE.md`. Nothing goes on the bus or into the SDK.

## 3. Secrets hygiene

TAK data packages carry a client private key + plaintext keystore passwords. Gitignore now covers `atak.zip`, `itak.zip`, and `*tak-data-package*.zip` so an enrollment package can't be committed by accident.

## Verification

All `connectors/tak` tests pass: 38 unit + 4 e2e; `ruff`/`black` clean. The rx_queue fix was verified against a live taky server with a real ATAK client in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)