### PR TITLE
chore: refresh uv.lock for keelson 0.5.3 + guard against lockfile drift in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,16 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      # Must run BEFORE `uv sync`: sync silently re-locks a stale lockfile in
+      # the working tree, which would mask the drift this guard is meant to
+      # catch. `--check` errors (without modifying anything) if uv.lock is out
+      # of sync with the pyproject.toml files — e.g. a version bump committed
+      # without re-locking. The requirements-prod.txt check below only covers
+      # the downstream export (and excludes workspace packages), so it cannot
+      # see this on its own.
+      - name: Check uv.lock is in sync with pyproject.toml
+        run: uv lock --check
+
       - name: Sync workspace
         run: uv sync --group dev
 

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "keelson"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "sdks/python" }
 dependencies = [
     { name = "eclipse-zenoh" },


### PR DESCRIPTION
## Summary

Fixes a stale lockfile **and** closes the CI gap that let it become stale.

`sdks/python/pyproject.toml` was bumped to `0.5.3` (commit `1378a7b "Bump to version 0.5.3"`) without regenerating `uv.lock`, which still pinned the `keelson` workspace package at `0.5.2`.

## Changes

1. **Refresh `uv.lock`** — `uv lock` → single-line update, `keelson 0.5.2 → 0.5.3`. No other dependency re-resolution. `requirements-prod.txt` is unchanged (workspace package isn't emitted with `--no-emit-workspace`), so the Docker/prod path is unaffected.

2. **Add a CI guard** — `uv lock --check` in the lint job, placed *before* `uv sync`.

### Why CI didn't catch this

The only existing lockfile guard was the `requirements-prod.txt` export check. It's blind to this class of drift because:
- **`--no-emit-workspace`** excludes workspace packages (`keelson`) from `requirements-prod.txt`, so a `keelson` version bump never produces a diff there.
- **`--frozen`** tells `uv export` to use the lockfile as-is, not re-resolve from `pyproject.toml`.
- Every other job runs `uv sync`, which silently re-locks a stale lockfile in the runner's working copy and proceeds — never failing, never committing.

`uv lock --check` asserts `uv.lock` is consistent with the `pyproject.toml` files (errors without modifying anything). It must run **before** `uv sync` for the reason above. This would have failed `1378a7b`'s CI.

Branched off `main`, isolated from the in-flight mediamtx work (#164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)