### PR TITLE
mediamtx: WHEP browser demo + TURN/CGNAT support and handler fix

### DIFF
--- a/connectors/mediamtx/README.md
+++ b/connectors/mediamtx/README.md
@@ -30,7 +30,7 @@ whep options:
   -i RESPONDER_ID, --responder-id RESPONDER_ID
                         Zenoh responder ID (required)
   -t TIMEOUT, --timeout TIMEOUT
-                        HTTP request timeout in seconds (default: 5)
+                        HTTP request timeout in seconds (default: 8)
 ```
 
 The setup at the MediaMTX end looks something like this:
@@ -57,3 +57,73 @@ services:
     ]
 
 ```
+
+### Browser debug client
+
+[`examples/browser-client-example.html`](examples/browser-client-example.html) is a
+self-contained, dependency-free demo page for quickly viewing a stream and
+debugging the signalling path. It does the WebRTC offer/answer handshake by
+sending a Zenoh `GET` query (a `WHEPRequest`) to the connector's `whep_signal`
+queryable and applying the returned `WHEPResponse` SDP — i.e. it exercises the
+exact same `WHEPProxy` path a real client would use, end to end.
+
+Because browsers can't speak the Zenoh protocol natively, the page talks to
+Zenoh over the
+[`zenoh-ts`](https://github.com/eclipse-zenoh/zenoh-ts) remote-api WebSocket
+(loaded from a CDN, pinned to match the project's Zenoh `1.7.x`). That requires a
+Zenoh router running the `zenoh-plugin-remote-api` plugin, listening on a
+WebSocket port (default `10000`):
+
+```json5
+// router config.json5
+{
+  mode: "router",
+  plugins: {
+    remote_api: { websocket_port: "10000" },
+  },
+}
+```
+
+Open the file in a browser (e.g. `python -m http.server` from this directory),
+fill in the remote-api WebSocket URL, realm, entity id, responder id and the
+MediaMTX path, then click **Start**. The page constructs the RPC key as
+`{realm}/@v0/{entity}/@rpc/whep_signal/{responder_id}`.
+
+## NAT traversal (CGNAT) — TURN
+
+WHEP signalling over Zenoh works through any NAT, but the **media** is a direct
+WebRTC connection. When MediaMTX runs behind **CGNAT** (e.g. a vessel on a 4G
+router), it has no externally reachable address and STUN can't help — the only
+candidate a viewer can reach is a **TURN relay candidate**. So MediaMTX must be
+configured with a TURN server, and `clientOnly` must stay unset/`false` so
+MediaMTX itself allocates a relay (that's the bit that fixes CGNAT):
+
+```
+MTX_WEBRTCICESERVERS2_0_URL=stun:stun.l.google.com:19302
+MTX_WEBRTCICESERVERS2_1_URL=turns:turn.<domain>:443?transport=tcp
+MTX_WEBRTCICESERVERS2_1_USERNAME=turnuser
+MTX_WEBRTCICESERVERS2_1_PASSWORD=<static-secret>
+```
+
+Notes:
+
+- **Use TLS/TCP on `443`** (`turns:…?transport=tcp`) — carriers often filter UDP
+  and odd ports. Don't add unreachable entries (e.g. `:80` UDP); MediaMTX's ICE
+  gathering waits on them and can blow past the WHEP/Zenoh timeouts.
+- **Self-host coturn** for static, non-metered credentials — example in
+  [`examples/coturn/`](examples/coturn/).
+- **No UDP at all?** Force relay-only on both sides (browser
+  `iceTransportPolicy: "relay"` + `turns:…?transport=tcp`); all media is then
+  TCP-relayed through coturn.
+
+The browser debug client above has matching TURN URL / username / credential
+fields and a **Force relay** checkbox for verifying the relay path.
+
+### Ready-to-use examples
+
+- [`examples/mediamtx-turn/docker-compose.yml`](examples/mediamtx-turn/docker-compose.yml)
+  — MediaMTX + WHEP proxy wired to a TURN server, drop-in.
+- [`examples/coturn/`](examples/coturn/) — self-hosted coturn behind Traefik
+  (setup + troubleshooting in its [README](examples/coturn/README.md)).
+- [`examples/verify-whep-turn.py`](examples/verify-whep-turn.py) — end-to-end
+  deployment check (needs `pip install aiortc`); see `-h`.

--- a/connectors/mediamtx/bin/mediamtx-whep.py
+++ b/connectors/mediamtx/bin/mediamtx-whep.py
@@ -52,7 +52,9 @@ def whep(session: zenoh.Session, args: argparse.Namespace):
                     "Missing a payload in the query. It should be of type WHEPRequest"
                 )
                 logging.error(message)
-                query.reply_err(ErrorResponse(message).SerializeToString())
+                query.reply_err(
+                    ErrorResponse(error_description=message).SerializeToString()
+                )
                 return
 
             try:
@@ -60,7 +62,9 @@ def whep(session: zenoh.Session, args: argparse.Namespace):
             except DecodeError as exc:
                 message = f"Failed to parse the body as a WHEPRequest: {exc}"
                 logging.exception(message)
-                query.reply_err(ErrorResponse(message).SerializeToString())
+                query.reply_err(
+                    ErrorResponse(error_description=message).SerializeToString()
+                )
                 return
 
             # Build full http url for the resource
@@ -78,14 +82,16 @@ def whep(session: zenoh.Session, args: argparse.Namespace):
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 message = f"WHEP request failed with reason: {exc}"
                 logging.exception(message)
-                query.reply_err(ErrorResponse(message).SerializeToString())
+                query.reply_err(
+                    ErrorResponse(error_description=message).SerializeToString()
+                )
                 return
 
             # Success, return response sdp
             logging.debug(
                 "Successful WHEP request, returning response SDP: %s", res.text
             )
-            query.reply(query.key_expr, WHEPResponse(res.text).SerializeToString())
+            query.reply(query.key_expr, WHEPResponse(sdp=res.text).SerializeToString())
 
 
 if __name__ == "__main__":
@@ -106,7 +112,10 @@ if __name__ == "__main__":
     whep_parser.set_defaults(func=whep)
     whep_parser.add_argument("--whep-host", type=str, required=True)
     whep_parser.add_argument("-i", "--responder-id", type=str, required=True)
-    whep_parser.add_argument("-t", "--timeout", type=int, default=5, required=False)
+    # Default kept under Zenoh's ~10s query timeout: a longer HTTP timeout is
+    # pointless because the requester gives up first. On-demand sources + ICE/TURN
+    # gathering routinely exceed the old 5s default on first connect.
+    whep_parser.add_argument("-t", "--timeout", type=int, default=8, required=False)
 
     # Parse arguments and start doing our thing
     args = parser.parse_args()

--- a/connectors/mediamtx/examples/browser-client-example.html
+++ b/connectors/mediamtx/examples/browser-client-example.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Keelson mediamtx — WHEP debug client</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, sans-serif;
+        }
+
+        body {
+            margin: 0 auto;
+            max-width: 920px;
+            padding: 16px;
+        }
+
+        h1 {
+            font-size: 1.25rem;
+        }
+
+        fieldset {
+            border: 1px solid #8884;
+            border-radius: 8px;
+            margin-bottom: 12px;
+        }
+
+        .field {
+            display: grid;
+            grid-template-columns: 180px 1fr;
+            gap: 8px;
+            align-items: center;
+            margin-bottom: 8px;
+        }
+
+        label {
+            font-size: 0.9rem;
+        }
+
+        input {
+            padding: 6px 8px;
+            font: inherit;
+        }
+
+        button {
+            padding: 8px 16px;
+            font: inherit;
+            cursor: pointer;
+        }
+
+        video {
+            width: 100%;
+            max-width: 1280px;
+            background: #0008;
+            border-radius: 8px;
+            margin-top: 12px;
+        }
+
+        #log {
+            white-space: pre-wrap;
+            font-family: ui-monospace, monospace;
+            font-size: 0.8rem;
+            background: #8881;
+            border-radius: 8px;
+            padding: 10px;
+            max-height: 220px;
+            overflow: auto;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Keelson <code>mediamtx</code> — WHEP debug client</h1>
+    <p>
+        Minimal browser client for the <code>mediamtx</code> connector's
+        <a href="https://rise-maritime.github.io/keelson/interfaces/#whepproxy"><code>WHEPProxy</code></a>
+        interface. It performs the WebRTC/WHEP handshake by sending a Zenoh
+        <code>GET</code> query (a <code>WHEPRequest</code>) to the connector's
+        <code>whep_signal</code> queryable and applying the returned
+        <code>WHEPResponse</code> SDP. It talks to Zenoh over the
+        <a href="https://github.com/eclipse-zenoh/zenoh-ts"><code>zenoh-ts</code></a>
+        remote-api WebSocket — see the README for the required router plugin.
+    </p>
+
+    <fieldset>
+        <legend>Zenoh</legend>
+        <div class="field">
+            <label for="ws">remote-api WebSocket</label>
+            <input id="ws" type="text" value="ws://localhost:10000" />
+        </div>
+        <div class="field">
+            <label for="realm">realm (base path)</label>
+            <input id="realm" type="text" value="myrealm" />
+        </div>
+        <div class="field">
+            <label for="entity">entity id</label>
+            <input id="entity" type="text" value="myentity" />
+        </div>
+        <div class="field">
+            <label for="responder">responder id</label>
+            <input id="responder" type="text" value="mediamtx" />
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>Stream</legend>
+        <div class="field">
+            <label for="path">mediamtx path</label>
+            <input id="path" type="text" value="example" />
+        </div>
+        <div class="field">
+            <label for="stun">STUN server</label>
+            <input id="stun" type="text" value="stun:stun.l.google.com:19302" />
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>TURN (only needed when MediaMTX is behind CGNAT)</legend>
+        <div class="field">
+            <label for="turn">TURN URL</label>
+            <input id="turn" type="text" placeholder="turns:turn.example.com:443?transport=tcp" />
+        </div>
+        <div class="field">
+            <label for="turnuser">TURN username</label>
+            <input id="turnuser" type="text" placeholder="(static credential)" />
+        </div>
+        <div class="field">
+            <label for="turncred">TURN credential</label>
+            <input id="turncred" type="text" />
+        </div>
+        <div class="field">
+            <label for="relayonly">Force relay</label>
+            <input id="relayonly" type="checkbox" />
+        </div>
+    </fieldset>
+
+    <button id="start">Start</button>
+    <button id="stop" disabled>Stop</button>
+
+    <video id="video" autoplay playsinline muted controls></video>
+    <h3>Log</h3>
+    <div id="log"></div>
+
+    <script type="module">
+        // zenoh-ts 1.7.x — must match the router's zenoh-plugin-remote-api version.
+        import { Config, Session, Sample } from "https://esm.sh/@eclipse-zenoh/zenoh-ts@1.7.2";
+
+        const $ = (id) => document.getElementById(id);
+        const logEl = $("log");
+        const log = (msg) => {
+            logEl.textContent += msg + "\n";
+            logEl.scrollTop = logEl.scrollHeight;
+            console.log(msg);
+        };
+
+        // --- Minimal protobuf wire encode/decode -------------------------------
+        // WHEPRequest  { string path = 1; string sdp = 2; }
+        // WHEPResponse { string sdp = 1; }
+        // The messages are trivial (proto3 strings), so we encode/decode the wire
+        // format by hand instead of pulling in a protobuf runtime.
+        const enc = new TextEncoder();
+        const dec = new TextDecoder();
+
+        function writeVarint(bytes, value) {
+            while (value > 0x7f) {
+                bytes.push((value & 0x7f) | 0x80);
+                value >>>= 7;
+            }
+            bytes.push(value);
+        }
+
+        function writeStringField(bytes, fieldNumber, str) {
+            const data = enc.encode(str);
+            bytes.push((fieldNumber << 3) | 2); // wire type 2 (length-delimited)
+            writeVarint(bytes, data.length);
+            for (const b of data) bytes.push(b);
+        }
+
+        function encodeWHEPRequest(path, sdp) {
+            const bytes = [];
+            if (path) writeStringField(bytes, 1, path);
+            if (sdp) writeStringField(bytes, 2, sdp);
+            return new Uint8Array(bytes);
+        }
+
+        function readVarint(buf, pos) {
+            let result = 0, shift = 0, byte;
+            do {
+                byte = buf[pos++];
+                result |= (byte & 0x7f) << shift;
+                shift += 7;
+            } while (byte & 0x80);
+            return [result >>> 0, pos];
+        }
+
+        // Returns the `sdp` (field 1) from a serialized WHEPResponse.
+        function decodeWHEPResponse(buf) {
+            let pos = 0;
+            while (pos < buf.length) {
+                let tag;
+                [tag, pos] = readVarint(buf, pos);
+                const fieldNumber = tag >>> 3;
+                const wireType = tag & 0x7;
+                if (wireType === 2) {
+                    let len;
+                    [len, pos] = readVarint(buf, pos);
+                    const slice = buf.subarray(pos, pos + len);
+                    pos += len;
+                    if (fieldNumber === 1) return dec.decode(slice);
+                } else if (wireType === 0) {
+                    [, pos] = readVarint(buf, pos);
+                } else {
+                    throw new Error(`unsupported wire type ${wireType}`);
+                }
+            }
+            return "";
+        }
+
+        // --- Keelson RPC key ----------------------------------------------------
+        // {base_path}/@v0/{entity_id}/@rpc/{procedure}/{responder_id}
+        function constructRpcKey(realm, entityId, procedure, responderId) {
+            return `${realm}/@v0/${entityId}/@rpc/${procedure}/${responderId}`;
+        }
+
+        // --- WebRTC + WHEP-over-Zenoh ------------------------------------------
+        let pc = null;
+        let session = null;
+
+        async function start() {
+            $("start").disabled = true;
+            try {
+                const wsUrl = $("ws").value.trim();
+                const key = constructRpcKey(
+                    $("realm").value.trim(),
+                    $("entity").value.trim(),
+                    "whep_signal",
+                    $("responder").value.trim(),
+                );
+                const path = $("path").value.trim();
+
+                // Build ICE servers: STUN always, TURN only if a URL is given.
+                const iceServers = [];
+                const stun = $("stun").value.trim();
+                if (stun) iceServers.push({ urls: [stun] });
+                const turn = $("turn").value.trim();
+                if (turn) iceServers.push({
+                    urls: [turn],
+                    username: $("turnuser").value.trim(),
+                    credential: $("turncred").value.trim(),
+                });
+                const rtcConfig = { iceServers };
+                // "Force relay" makes the browser use only its TURN allocation —
+                // the zero-UDP / relay-only path, and a quick way to prove TURN works.
+                if ($("relayonly").checked) rtcConfig.iceTransportPolicy = "relay";
+                log("ICE: " + iceServers.map((s) => s.urls).join(", ") +
+                    (rtcConfig.iceTransportPolicy === "relay" ? " (relay-only)" : ""));
+
+                pc = new RTCPeerConnection(rtcConfig);
+                pc.addEventListener("track", (evt) => {
+                    log(`track received: ${evt.track.kind}`);
+                    $("video").srcObject = evt.streams[0];
+                });
+                pc.addEventListener("connectionstatechange", () =>
+                    log(`peer connection: ${pc.connectionState}`));
+                pc.addTransceiver("video", { direction: "recvonly" });
+                pc.addTransceiver("audio", { direction: "recvonly" });
+
+                log("creating offer...");
+                const offer = await pc.createOffer();
+                await pc.setLocalDescription(offer);
+                await waitForIceGathering(pc);
+                const offerSdp = pc.localDescription.sdp;
+
+                log(`opening zenoh session to ${wsUrl}...`);
+                session = await Session.open(new Config(wsUrl));
+
+                log(`querying ${key} (path="${path}")...`);
+                const payload = encodeWHEPRequest(path, offerSdp);
+                const receiver = await session.get(key, { payload });
+
+                let answerSdp = null;
+                for await (const reply of receiver) {
+                    const result = reply.result();
+                    if (result instanceof Sample) {
+                        answerSdp = decodeWHEPResponse(result.payload().toBytes());
+                        break;
+                    } else {
+                        const errBytes = result.payload().toBytes();
+                        throw new Error(`reply error: ${dec.decode(errBytes)}`);
+                    }
+                }
+
+                if (!answerSdp) throw new Error("no reply received (is the connector running?)");
+
+                log("applying answer SDP...");
+                await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+                log("handshake complete — waiting for media.");
+                $("stop").disabled = false;
+            } catch (err) {
+                log(`ERROR: ${err.message ?? err}`);
+                await stop();
+            }
+        }
+
+        async function stop() {
+            $("stop").disabled = true;
+            if (pc) { pc.close(); pc = null; }
+            if (session) {
+                try { await session.close(); } catch { /* ignore */ }
+                session = null;
+            }
+            $("video").srcObject = null;
+            $("start").disabled = false;
+            log("stopped.");
+        }
+
+        function waitForIceGathering(pc) {
+            if (pc.iceGatheringState === "complete") return Promise.resolve();
+            return new Promise((resolve) => {
+                const check = () => {
+                    if (pc.iceGatheringState === "complete") {
+                        pc.removeEventListener("icegatheringstatechange", check);
+                        resolve();
+                    }
+                };
+                pc.addEventListener("icegatheringstatechange", check);
+            });
+        }
+
+        $("start").addEventListener("click", start);
+        $("stop").addEventListener("click", stop);
+    </script>
+</body>
+
+</html>

--- a/connectors/mediamtx/examples/coturn/README.md
+++ b/connectors/mediamtx/examples/coturn/README.md
@@ -1,0 +1,44 @@
+# coturn behind Traefik — TURN/TLS for MediaMTX over CGNAT
+
+A minimal, set-once [coturn](https://github.com/coturn/coturn) that gives
+MediaMTX a **TURN relay over TLS on `443`**, so WebRTC media reaches viewers
+even when MediaMTX is behind CGNAT.
+
+```
+camera → MediaMTX (CGNAT) ──relay──▶ coturn (turn.<domain>:443/TLS) ──relay──▶ viewer
+```
+
+Traefik terminates TLS on `443` (its ACME manages the cert) and forwards the
+decrypted TURN stream to coturn's plain `listening-port` on loopback — coturn
+needs no cert of its own.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | coturn in `network_mode: host` |
+| `turnserver.conf` | credentials, relay range, relay-IP |
+| `traefik-dynamic.yml` | Traefik file-provider TCP router: `HostSNI(turn.<domain>)` → coturn |
+
+## Setup
+
+1. Set a secret in `turnserver.conf` (`openssl rand -hex 24`); client uses `username=turnuser` + that secret.
+2. Point `turn.<domain>` DNS at the host's public IP.
+3. Open **inbound UDP `49150-49200`** (matches `min-port`/`max-port`). `443` is already served by Traefik.
+4. If behind 1:1 NAT or with Docker bridges present, set `relay-ip`/`external-ip` (see `turnserver.conf`).
+5. In `traefik-dynamic.yml`, pick the backend address matching how Traefik reaches coturn.
+
+Verify TLS: `openssl s_client -connect turn.<domain>:443 -servername turn.<domain> -brief </dev/null`.
+For an end-to-end media check, use [`../verify-whep-turn.py`](../verify-whep-turn.py).
+
+## Troubleshooting
+
+The `turns:` path has three hops, each failing differently:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| TLS handshake EOF, no cert | Traefik router matched but ACME hasn't issued a cert | check `certresolver` name + Traefik ACME logs |
+| backend **refused** (instant) | wrong loopback (`127.0.0.1` while Traefik is bridged) | use `host.docker.internal:3478` + `extra_hosts: ["host.docker.internal:host-gateway"]` |
+| backend **hangs** | host firewall drops the bridge→host hop | `ufw allow from 172.16.0.0/12 to any port 3478 proto tcp` |
+| connects, no media; `typ relay` candidate has a **private** IP | coturn advertised a non-public interface | set `relay-ip`/`external-ip` in `turnserver.conf` |
+| `403 Forbidden IP` in client logs | `denied-peer-ip` refusing a private target | harmless if a valid relay pair is still found |

--- a/connectors/mediamtx/examples/coturn/docker-compose.yml
+++ b/connectors/mediamtx/examples/coturn/docker-compose.yml
@@ -1,0 +1,17 @@
+# coturn TURN server for MediaMTX WebRTC over CGNAT.
+#
+# Host networking is used deliberately: it keeps the dynamic UDP relay range and
+# relay-IP handling out of Docker NAT, which is the robust way to run coturn. The
+# trade-off is that the container is invisible to Traefik's label discovery, so the
+# router lives in the file-provider snippet (traefik-dynamic.yml) instead of labels.
+#
+# Firewall (IT): open inbound UDP 49150-49200 only. TCP 443 is already served by
+# Traefik; coturn's plain 3478 stays internal (not opened).
+services:
+  coturn:
+    image: coturn/coturn:4.6
+    network_mode: host
+    restart: unless-stopped
+    command: ["-c", "/etc/coturn/turnserver.conf"]
+    volumes:
+      - ./turnserver.conf:/etc/coturn/turnserver.conf:ro

--- a/connectors/mediamtx/examples/coturn/traefik-dynamic.yml
+++ b/connectors/mediamtx/examples/coturn/traefik-dynamic.yml
@@ -1,0 +1,26 @@
+# Traefik dynamic config (file provider) routing turn.example.com:443 to coturn.
+#
+# Traefik TERMINATES TLS here (and ACME-manages the cert via your resolver), then
+# forwards the decrypted TURN/TCP stream to coturn's plain :3478. Clients still use
+# turns: (TLS) — only the Traefik->coturn hop is plaintext, and that's loopback.
+
+
+## Dynamic configuration
+tcp:
+  routers:
+    coturn-tcp:
+      rule: "HostSNI(`turn.example.com`)"
+      entrypoints: websecure
+      tls:
+        certresolver: LEresolver
+      service: coturn-tcp
+
+
+  services:
+    coturn-tcp:
+      loadBalancer:
+        servers:
+          # How Traefik reaches the host-networked coturn:
+          - address: "127.0.0.1:3478"          # if Traefik also runs host-networked
+          # - address: "host.docker.internal:3478"   # if Traefik is in a bridge net;
+          #   then add to Traefik:  extra_hosts: ["host.docker.internal:host-gateway"]

--- a/connectors/mediamtx/examples/coturn/turnserver.conf
+++ b/connectors/mediamtx/examples/coturn/turnserver.conf
@@ -1,0 +1,32 @@
+# coturn config for relaying MediaMTX WebRTC through CGNAT.
+# Runs in host networking; Traefik terminates TLS on :443 and forwards the
+# decrypted TURN/TCP stream to the plain listener below.
+
+realm=example.com
+fingerprint
+no-cli
+
+# Long-term static credentials — no rotation. Generate a secret with:
+#   openssl rand -hex 24
+lt-cred-mech
+user=turnuser:REPLACE_WITH_LONG_RANDOM_SECRET
+
+# Plain listener. Not opened in the firewall — only Traefik (loopback) reaches it.
+listening-port=3478
+
+# UDP relay range — MUST equal the inbound-UDP firewall rule opened by IT.
+min-port=49150
+max-port=49200
+
+# Relay address advertised to clients (the `typ relay` candidate) — MUST be the
+# public IP a remote viewer can reach. Omit if the public IP is directly on the
+# NIC with no other interfaces. Set both when behind 1:1 NAT (public != NIC), or
+# when host networking exposes Docker bridges coturn might otherwise pick:
+# relay-ip=PRIVATE_IP                 # routable NIC where inbound UDP lands
+# external-ip=PUBLIC_IP/PRIVATE_IP    # advertise PUBLIC, bind to PRIVATE
+
+# Optional hardening: refuse to relay to internal ranges. Leave commented if the
+# relay-to-relay (zero-UDP) path is ever used with a private relay-ip.
+# denied-peer-ip=10.0.0.0-10.255.255.255
+# denied-peer-ip=172.16.0.0-172.31.255.255
+# denied-peer-ip=192.168.0.0-192.168.255.255

--- a/connectors/mediamtx/examples/mediamtx-turn/docker-compose.yml
+++ b/connectors/mediamtx/examples/mediamtx-turn/docker-compose.yml
@@ -1,0 +1,25 @@
+# MediaMTX + WHEP-over-Zenoh proxy relaying WebRTC media through a self-hosted
+# coturn TURN server (see ../coturn/) so streams reach viewers behind CGNAT.
+# Fill in the <...> placeholders.
+version: '3.9'
+
+services:
+
+  mediamtx:
+    image: bluenviron/mediamtx
+    restart: unless-stopped
+    environment:
+      - MTX_PATHS_<path>_SOURCE=rtsp://url-to-your-camera
+      - MTX_WEBRTCICESERVERS2_0_URL=stun:stun.l.google.com:19302
+      # TURN over TLS/TCP on 443 — the relay that fixes CGNAT.
+      - MTX_WEBRTCICESERVERS2_1_URL=turns:turn.<domain>:443?transport=tcp
+      - MTX_WEBRTCICESERVERS2_1_USERNAME=turnuser
+      - MTX_WEBRTCICESERVERS2_1_PASSWORD=<coturn-secret>
+      # Leave CLIENTONLY unset — MediaMTX must allocate its own relay candidate.
+
+  whep-proxy:
+    image: ghcr.io/rise-maritime/keelson
+    restart: unless-stopped
+    command: [
+        "mediamtx-whep --mode client --connect tcp/<zenoh-router-host>:7447 -r <realm> -e <entity> whep -i mediamtx --whep-host http://mediamtx:8889 -t 8"
+    ]

--- a/connectors/mediamtx/examples/verify-whep-turn.py
+++ b/connectors/mediamtx/examples/verify-whep-turn.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Verify a Keelson WHEP + TURN deployment end to end.
+
+Checks, in order:
+  1. The whep_signal RPC returns an SDP answer (not an error).
+  2. MediaMTX advertised a `typ relay` candidate with a PUBLIC address
+     (catches the private-relay-IP misconfig: missing relay-ip/external-ip).
+  3. With --turn, the local client also relays through coturn, ICE reaches
+     `completed`, and real video frames are decoded — proof media flows.
+
+Requires aiortc for the media test:  pip install aiortc
+
+  # signalling + relay-candidate check (no TURN creds needed):
+  ./verify-whep-turn.py -r <realm> -e <entity> -p <path>
+
+  # full media test (local client relays through coturn too):
+  ./verify-whep-turn.py -r <realm> -e <entity> -p <path> \
+      --turn 'turns:turn.example.com:443?transport=tcp' \
+      --turn-user turnuser --turn-pass "$TURN_SECRET"
+"""
+import argparse
+import asyncio
+import ipaddress
+import json
+import re
+import sys
+
+import zenoh
+import keelson
+from keelson.interfaces.WHEPProxy_pb2 import WHEPRequest, WHEPResponse
+from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description="Verify a Keelson WHEP + TURN deployment end to end.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument("-r", "--realm", required=True, help="Keelson base path / realm")
+    ap.add_argument("-e", "--entity-id", required=True, help="connector entity id")
+    ap.add_argument(
+        "-i", "--responder-id", default="mediamtx", help="whep responder id"
+    )
+    ap.add_argument("-p", "--path", required=True, help="MediaMTX path (lower-cased)")
+    ap.add_argument(
+        "--connect",
+        default="tcp/localhost:7447",
+        help="zenoh router endpoint to connect to (client mode)",
+    )
+    ap.add_argument("--timeout", type=int, default=15, help="zenoh GET timeout (s)")
+    ap.add_argument(
+        "--turn", help="TURN url, e.g. turns:turn.example.com:443?transport=tcp"
+    )
+    ap.add_argument("--turn-user", help="TURN username")
+    ap.add_argument("--turn-pass", help="TURN credential")
+    ap.add_argument("--stun", default="stun:stun.l.google.com:19302", help="STUN url")
+    ap.add_argument(
+        "--media-timeout",
+        type=int,
+        default=30,
+        help="seconds to wait for ICE + first frames",
+    )
+    return ap.parse_args()
+
+
+def relay_candidates(sdp: str) -> list[str]:
+    return [
+        c.strip()
+        for c in re.findall(r"^a=candidate:.*$", sdp, re.MULTILINE)
+        if " typ relay" in c
+    ]
+
+
+def is_public(addr: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(addr)
+        return not (ip.is_private or ip.is_loopback or ip.is_link_local)
+    except ValueError:
+        return False  # mDNS / hostname -> treat as "not a verifiable public IP"
+
+
+def signal(args: argparse.Namespace, offer_sdp: str) -> tuple[bool, str]:
+    """Send the WHEPRequest via the whep_signal RPC; return (ok, sdp-or-error)."""
+    conf = zenoh.Config()
+    conf.insert_json5("mode", json.dumps("client"))
+    conf.insert_json5("connect/endpoints", json.dumps([args.connect]))
+    key = keelson.construct_rpc_key(
+        base_path=args.realm,
+        entity_id=args.entity_id,
+        procedure="whep_signal",
+        responder_id=args.responder_id,
+    )
+    req = WHEPRequest(path=args.path, sdp=offer_sdp)
+    with zenoh.open(conf) as session:
+        for reply in session.get(
+            key, payload=req.SerializeToString(), timeout=args.timeout
+        ):
+            if reply.ok:
+                return True, WHEPResponse.FromString(reply.ok.payload.to_bytes()).sdp
+            try:
+                return False, str(
+                    ErrorResponse.FromString(reply.err.payload.to_bytes())
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                return False, reply.err.payload.to_bytes().decode("utf-8", "replace")
+    return (
+        False,
+        "NO REPLY (queryable unreachable — check realm/entity/responder/router)",
+    )
+
+
+async def wait_for_gathering(pc) -> None:
+    if pc.iceGatheringState == "complete":
+        return
+    done = asyncio.Event()
+
+    @pc.on("icegatheringstatechange")
+    def _():  # noqa: ANN202
+        if pc.iceGatheringState == "complete":
+            done.set()
+
+    await asyncio.wait_for(done.wait(), timeout=30)
+
+
+async def run(args: argparse.Namespace) -> int:
+    # Import here so the signalling-only path works without aiortc installed.
+    try:
+        from aiortc import (  # noqa: PLC0415
+            RTCPeerConnection,
+            RTCSessionDescription,
+            RTCConfiguration,
+            RTCIceServer,
+        )
+    except ImportError:
+        print(
+            "ERROR: aiortc is required. Install with:  pip install aiortc",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"=== verify WHEP+TURN: realm={args.realm} entity={args.entity_id} "
+        f"responder={args.responder_id} path={args.path!r} ==="
+    )
+
+    ice = []
+    if args.turn:
+        if not (args.turn_user and args.turn_pass):
+            print("ERROR: --turn requires --turn-user and --turn-pass", file=sys.stderr)
+            return 2
+        ice.append(
+            RTCIceServer(
+                urls=[args.turn], username=args.turn_user, credential=args.turn_pass
+            )
+        )
+    if args.stun:
+        ice.append(RTCIceServer(urls=[args.stun]))
+
+    pc = RTCPeerConnection(RTCConfiguration(iceServers=ice))
+    pc.addTransceiver("video", direction="recvonly")
+    pc.addTransceiver("audio", direction="recvonly")
+
+    video = {"track": None}
+
+    @pc.on("track")
+    def on_track(track):  # noqa: ANN001, ANN202
+        print(f"  [track] {track.kind}")
+        if track.kind == "video":
+            video["track"] = track
+
+    @pc.on("iceconnectionstatechange")
+    def on_ice():  # noqa: ANN202
+        print(f"  [ice] {pc.iceConnectionState}")
+
+    await pc.setLocalDescription(await pc.createOffer())
+    if args.turn:
+        # WHEP is non-trickle: the offer must carry our candidates (incl. relay).
+        print("  gathering local ICE candidates (incl. TURN relay)...")
+        await wait_for_gathering(pc)
+        mine = relay_candidates(pc.localDescription.sdp)
+        print(f"  local relay candidates: {len(mine)}")
+
+    # --- Check 1: signalling round-trip --------------------------------------
+    print("\n[1] signalling whep_signal RPC...")
+    ok, answer = signal(args, pc.localDescription.sdp)
+    if not ok:
+        print(f"  FAIL — RPC returned an error:\n    {answer}")
+        await pc.close()
+        return 1
+    print("  OK — got SDP answer")
+
+    # --- Check 2: public relay candidate -------------------------------------
+    print("\n[2] inspecting MediaMTX relay candidate(s)...")
+    relays = relay_candidates(answer)
+    if not relays:
+        print(
+            "  FAIL — no `typ relay` candidate. MediaMTX did not allocate a relay "
+            "(check its TURN url/creds and coturn reachability)."
+        )
+        await pc.close()
+        return 1
+    public_ok = False
+    for c in relays:
+        addr = c.split()[
+            4
+        ]  # a=candidate:<foundation> <comp> <proto> <prio> <ADDR> <port> ...
+        tag = "PUBLIC ✓" if is_public(addr) else "PRIVATE ✗"
+        print(f"  {tag}  {c}")
+        public_ok = public_ok or is_public(addr)
+    if not public_ok:
+        print(
+            "  FAIL — relay candidate has a private/internal address. "
+            "Set relay-ip + external-ip in turnserver.conf (see examples/coturn/README.md #3)."
+        )
+        await pc.close()
+        return 1
+    print("  OK — relay candidate advertises a public address")
+
+    # --- Check 3: media (only when this client can relay too) ----------------
+    if not args.turn:
+        print(
+            "\n[3] media test SKIPPED (no --turn on this client; "
+            "signalling + relay-candidate checks passed). "
+            "Use a browser on a real network, or pass --turn/--turn-user/--turn-pass."
+        )
+        await pc.close()
+        return 0
+
+    # Applying the answer starts ICE — only do it when we intend to test media.
+    await pc.setRemoteDescription(RTCSessionDescription(sdp=answer, type="answer"))
+
+    print("\n[3] waiting for ICE + decoding frames...")
+    for _ in range(args.media_timeout * 2):
+        if pc.iceConnectionState in ("connected", "completed", "failed", "closed"):
+            break
+        await asyncio.sleep(0.5)
+    if (
+        pc.iceConnectionState not in ("connected", "completed")
+        or video["track"] is None
+    ):
+        print(
+            f"  FAIL — ICE never connected (state {pc.iceConnectionState}, "
+            f"video track={'yes' if video['track'] else 'no'}). "
+            "Transport-level failure: check TURN creds and relay reachability."
+        )
+        await pc.close()
+        return 1
+    try:
+        for n in range(5):
+            frame = await asyncio.wait_for(video["track"].recv(), timeout=15)
+            print(f"  frame {n}: {frame.width}x{frame.height} pts={frame.pts}")
+    except (
+        asyncio.TimeoutError,
+        Exception,
+    ) as exc:  # pylint: disable=broad-exception-caught
+        kind = "timed out" if isinstance(exc, asyncio.TimeoutError) else repr(exc)
+        print(
+            f"  FAIL — ICE connected ({pc.iceConnectionState}) but no frames decoded ({kind}).\n"
+            "         The relay path is up but no RTP arrived — most likely the upstream\n"
+            f"         source for path '{args.path}' is not producing media right now\n"
+            "         (camera offline / RTSP source down), not a TURN problem."
+        )
+        await pc.close()
+        return 1
+
+    print("\n*** PASS — media flowing end to end through coturn ***")
+    await pc.close()
+    return 0
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        sys.exit(asyncio.run(run(args)))
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes the MediaMTX WHEP-over-Zenoh connector usable from a browser and over **CGNAT**, adds a self-hosted TURN (coturn) example, and fixes a crash in the WHEP handler.

## Changes

- **WHEP browser debug client** (`examples/browser-client-example.html`) — dependency-free, exercises the `whep_signal` RPC path over `zenoh-ts`; has TURN URL/credential fields and a Force-relay checkbox.
- **TURN / CGNAT support** — MediaMTX ICE-server config + docs; bump the WHEP HTTP timeout (ICE/TURN gathering on first connect exceeds the old default).
- **coturn example** (`examples/coturn/`) — coturn behind a Traefik TLS-terminating TCP router (`HostSNI(turn.<domain>)`), with setup + a concise troubleshooting table.
- **`examples/mediamtx-turn/docker-compose.yml`** — drop-in MediaMTX + WHEP proxy wired to a TURN server.
- **`examples/verify-whep-turn.py`** — end-to-end deployment check: signals over Zenoh, asserts a **public** `typ relay` candidate, and (with `--turn`) relays through coturn to decode real frames. Needs `pip install aiortc` for the media test.
- **WHEP handler fix** — construct `ErrorResponse`/`WHEPResponse` with explicit protobuf fields; positional args raise `TypeError` on every reply.

All example values are neutral placeholders (`example.com`, `<realm>`/`<entity>`/`<path>`, `turnuser`).

## Notes

- Squashed/clean history; supersedes #164 (rewritten to remove deployment-specific values from history).
- Verified end-to-end against a live deployment: signalling RPC, public relay candidate, and decoded video frames through the relay. `ruff` + `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)