### PR TITLE
[stacked on #169] feat(foxglove): advertise live keelson RPC endpoints as Foxglove services

### DIFF
--- a/connectors/foxglove/README.md
+++ b/connectors/foxglove/README.md
@@ -9,6 +9,7 @@ usage: foxglove-liveview [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
                          [--connect CONNECT] [--listen LISTEN] -k KEY
                          [--ws-host WS_HOST] [--ws-port WS_PORT]
                          [--extra-subjects-types EXTRA_SUBJECTS_TYPES]
+                         [--expose-rpc-services EXPOSE_RPC_SERVICES]
 
 A foxglove websocket server for keelson
 
@@ -26,4 +27,48 @@ options:
   --extra-subjects-types EXTRA_SUBJECTS_TYPES
                         Add additional well-known subjects and protobuf types as --extra-subjects-
                         types=path/to/subjects.yaml,path_to_protobuf_file_descriptor_set.bin (default: None)
+  --expose-rpc-services EXPOSE_RPC_SERVICES
+                        Advertise all live keelson RPC endpoints under this base path as Foxglove
+                        services (default: None)
 ```
+
+### RPC services
+
+Passing `--expose-rpc-services BASE_PATH` (repeatable, one per base path/realm)
+turns on a bridge that advertises every live keelson RPC endpoint under that
+base path as a callable Foxglove service. Discovery is driven entirely by
+interface-level liveliness — connectors don't need any foxglove-specific
+code to show up:
+
+- When an `(interface, version)` liveliness token joins the bus (e.g. a
+  connector starts serving `replay_control/v1` via
+  `keelson.scaffolding.serve_rpc`), one Foxglove service is advertised per
+  procedure defined by that interface version.
+- When the token leaves (the connector stops or disconnects), its services
+  are removed from the Foxglove server.
+- Foxglove Studio / app users connected to the websocket see services
+  appear and disappear live as connectors come and go — no restart of
+  `foxglove-liveview` required.
+
+**Service naming.** Each service is named
+`{entity_id}/{interface}/{version}/{procedure}/{source_id}`, matching the
+keelson RPC key's addressing components.
+
+**Only well-known interfaces are advertised.** An `(interface, version)`
+liveliness token is only turned into services if it's registered in this
+SDK's bundled `interfaces.yaml`. A live interface that isn't well-known
+(e.g. a newer interface served by a connector running a newer SDK release)
+is logged as a warning and skipped — it does not stop the bridge from
+advertising everything else.
+
+**JSON payload caveat for `configurable/v1`.** `configurable/v1`'s
+`get_config`/`set_config` procedures use a `JSON{}` message as a
+placeholder — it isn't a real protobuf-typed payload, it's a raw JSON
+string carried as the request/response bytes. Callers invoking these two
+services through Foxglove should send/expect a raw JSON string, not a
+`JSON` protobuf message.
+
+**Threading note.** Each service call runs `invoke_procedure` synchronously
+(blocking up to a 10s timeout) on the Foxglove server's own handler thread.
+This is fine for v1 given keelson's single-reply RPC semantics: a slow or
+unresponsive responder only holds up that one handler thread.

--- a/connectors/foxglove/README.md
+++ b/connectors/foxglove/README.md
@@ -10,6 +10,7 @@ usage: foxglove-liveview [-h] [--log-level LOG_LEVEL] [--mode {peer,client}]
                          [--ws-host WS_HOST] [--ws-port WS_PORT]
                          [--extra-subjects-types EXTRA_SUBJECTS_TYPES]
                          [--expose-rpc-services EXPOSE_RPC_SERVICES]
+                         [--rpc-call-timeout RPC_CALL_TIMEOUT]
 
 A foxglove websocket server for keelson
 
@@ -30,6 +31,11 @@ options:
   --expose-rpc-services EXPOSE_RPC_SERVICES
                         Advertise all live keelson RPC endpoints under this base path as Foxglove
                         services (default: None)
+  --rpc-call-timeout RPC_CALL_TIMEOUT
+                        Timeout (seconds) for RPC calls made on behalf of Foxglove clients. Each
+                        call blocks one Foxglove handler thread for up to this long if the
+                        responder is dead, so keep it as low as your slowest procedure allows.
+                        (default: 10.0)
 ```
 
 ### RPC services
@@ -51,8 +57,10 @@ code to show up:
   `foxglove-liveview` required.
 
 **Service naming.** Each service is named
-`{entity_id}/{interface}/{version}/{procedure}/{source_id}`, matching the
-keelson RPC key's addressing components.
+`{base_path}/{entity_id}/{interface}/{version}/{procedure}/{source_id}`,
+matching the keelson RPC key's addressing components. The `base_path`
+prefix keeps names unambiguous (and collision-free) when multiple
+`--expose-rpc-services` base paths are monitored.
 
 **Only well-known interfaces are advertised.** An `(interface, version)`
 liveliness token is only turned into services if it's registered in this
@@ -61,14 +69,27 @@ SDK's bundled `interfaces.yaml`. A live interface that isn't well-known
 is logged as a warning and skipped — it does not stop the bridge from
 advertising everything else.
 
-**JSON payload caveat for `configurable/v1`.** `configurable/v1`'s
-`get_config`/`set_config` procedures use a `JSON{}` message as a
-placeholder — it isn't a real protobuf-typed payload, it's a raw JSON
-string carried as the request/response bytes. Callers invoking these two
-services through Foxglove should send/expect a raw JSON string, not a
-`JSON` protobuf message.
+**Calls are a raw byte passthrough.** The bridge forwards the Foxglove
+request payload to the responder unmodified and returns the reply bytes
+unmodified — no protobuf decode/re-encode in the middle. For protobuf
+procedures this is equivalent to a typed call; for JSON-placeholder
+procedures it's what makes them work at all (see below). A typed
+`ErrorResponse` from the responder is surfaced to the Foxglove client as
+an error string like `INVALID_STATE: no file loaded`; no reply within
+`--rpc-call-timeout` surfaces as a timeout error naming the endpoint.
 
-**Threading note.** Each service call runs `invoke_procedure` synchronously
-(blocking up to a 10s timeout) on the Foxglove server's own handler thread.
-This is fine for v1 given keelson's single-reply RPC semantics: a slow or
-unresponsive responder only holds up that one handler thread.
+**JSON payloads (`configurable/v1`).** `configurable/v1`'s
+`get_config`/`set_config` procedures use a `JSON{}` protobuf message as a
+placeholder — the actual request/response bytes are a raw JSON string,
+not a protobuf payload. The bridge detects placeholder sides (message
+full name ending in `.JSON`) and advertises them with `json` encoding and
+a permissive JSON schema, so Foxglove presents a JSON input and displays
+a JSON response. Combined with the raw passthrough, `configurable/v1`
+services are fully callable from Foxglove: type JSON in, get JSON back.
+
+**Threading note.** Each service call runs the zenoh query synchronously
+(blocking up to `--rpc-call-timeout`, default 10 s) on the Foxglove
+server's own handler thread. This is fine for v1 given keelson's
+single-reply RPC semantics, but a dead responder pins that one handler
+thread for the full timeout — keep the timeout as low as your slowest
+procedure allows.

--- a/connectors/foxglove/bin/keelson2foxglove.py
+++ b/connectors/foxglove/bin/keelson2foxglove.py
@@ -7,7 +7,7 @@ import argparse
 import functools
 from typing import Dict
 from queue import Queue, Empty
-from threading import Thread
+from threading import Thread, Lock
 
 import zenoh
 import keelson
@@ -25,6 +25,7 @@ from foxglove.websocket import (
     ServerListener,
 )
 from google.protobuf.message import DecodeError
+from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
 from keelson.scaffolding import (
     setup_logging,
     add_common_arguments,
@@ -82,94 +83,126 @@ class RpcServiceBridge:
     services. Only interfaces registered in this SDK's ``interfaces.yaml``
     can be advertised (unknown interfaces are skipped with a warning).
 
-    Note: service handlers run ``invoke_procedure`` synchronously
-    (blocking up to ``timeout``) on the foxglove server's own handler
-    thread. This is acceptable for v1 and matches keelson's single-reply
-    RPC semantics; a slow/unresponsive responder will hold up that one
-    handler thread but not the rest of the bridge.
+    Calls are a raw byte passthrough: the Foxglove request payload is sent
+    unmodified on the RPC key, and the responder's reply bytes are returned
+    unmodified. This keeps JSON-placeholder procedures (e.g.
+    ``configurable/v1``'s raw-JSON-string payloads) callable exactly like
+    protobuf ones.
+
+    Note: service handlers run the zenoh query synchronously (blocking up
+    to ``call_timeout``) on the foxglove server's own handler thread. This
+    is acceptable for v1 and matches keelson's single-reply RPC semantics;
+    a slow/unresponsive responder will pin that one handler thread for up
+    to the timeout, but not the rest of the bridge.
     """
 
-    def __init__(self, session: zenoh.Session, server: foxglove.WebSocketServer):
+    def __init__(
+        self,
+        session: zenoh.Session,
+        server: foxglove.WebSocketServer,
+        call_timeout: float = 10.0,
+    ):
         self._session = session
         self._server = server
+        self._call_timeout = call_timeout
         self._fds_bytes = keelson.interfaces.get_interfaces_file_descriptor_set()
-        # token_key -> list of Foxglove service names advertised for it
+        # token_key -> list of Foxglove service names advertised for it.
+        # Guarded by _lock: on_join/on_leave run on per-monitor zenoh
+        # callback threads while close() runs on the main thread.
         self._services: Dict[str, list] = {}
+        self._lock = Lock()
+
+    def _message_schema(self, descriptor) -> MessageSchema:
+        """Build the Foxglove MessageSchema for one side of a procedure.
+
+        A ``JSON{}`` message (full name ending in ``.JSON``) is keelson's
+        placeholder convention for "this side carries a raw JSON string,
+        not a protobuf payload" — advertise it as json/jsonschema so
+        Foxglove presents a JSON input; everything else is protobuf.
+        """
+        if descriptor.full_name.endswith(".JSON"):
+            return MessageSchema(
+                encoding="json",
+                schema=Schema(
+                    name=descriptor.full_name,
+                    encoding="jsonschema",
+                    data=b'{"type":"object"}',
+                ),
+            )
+        return MessageSchema(
+            encoding="protobuf",
+            schema=Schema(
+                name=descriptor.full_name,
+                encoding="protobuf",
+                data=self._fds_bytes,
+            ),
+        )
 
     def on_join(self, token_key: str) -> None:
-        # Guard against a rejoin after a transient reconnect re-declaring
-        # the same liveliness token — treat it as a no-op.
-        if token_key in self._services:
-            return
+        with self._lock:
+            # Guard against a rejoin after a transient reconnect re-declaring
+            # the same liveliness token — treat it as a no-op.
+            if token_key in self._services:
+                return
 
-        try:
-            parsed = keelson.parse_rpc_interface_liveliness_key(token_key)
-        except ValueError:
-            logger.debug(
-                "Liveliness key %s did not match the RPC interface pattern; ignoring",
-                token_key,
-            )
-            return
+            try:
+                parsed = keelson.parse_rpc_interface_liveliness_key(token_key)
+            except ValueError:
+                logger.debug(
+                    "Liveliness key %s did not match the RPC interface pattern; ignoring",
+                    token_key,
+                )
+                return
 
-        base_path = parsed["base_path"]
-        entity_id = parsed["entity_id"]
-        interface = parsed["interface"]
-        version = parsed["version"]
-        source_id = parsed["source_id"]
+            base_path = parsed["base_path"]
+            entity_id = parsed["entity_id"]
+            interface = parsed["interface"]
+            version = parsed["version"]
+            source_id = parsed["source_id"]
 
-        if not keelson.is_interface_well_known(f"{interface}/{version}"):
-            logger.warning(
-                "Live interface %s/%s (entity=%s, source=%s) is not in this "
-                "SDK's interfaces.yaml — skipping",
-                interface,
-                version,
-                entity_id,
-                source_id,
-            )
-            # Record an empty entry so we don't re-warn on rejoin.
-            self._services[token_key] = []
-            return
+            if not keelson.is_interface_well_known(f"{interface}/{version}"):
+                logger.warning(
+                    "Live interface %s/%s (entity=%s, source=%s) is not in this "
+                    "SDK's interfaces.yaml — skipping",
+                    interface,
+                    version,
+                    entity_id,
+                    source_id,
+                )
+                # Record an empty entry so we don't re-warn on rejoin.
+                self._services[token_key] = []
+                return
 
-        services = []
-        names = []
-        for procedure in keelson.interfaces.get_procedures(interface, version):
-            request_desc, response_desc = keelson.interfaces.get_procedure_schemas(
-                interface, version, procedure
-            )
-            name = f"{entity_id}/{interface}/{version}/{procedure}/{source_id}"
-            schema = ServiceSchema(
-                name=name,
-                request=MessageSchema(
-                    encoding="protobuf",
-                    schema=Schema(
-                        name=request_desc.full_name,
-                        encoding="protobuf",
-                        data=self._fds_bytes,
-                    ),
-                ),
-                response=MessageSchema(
-                    encoding="protobuf",
-                    schema=Schema(
-                        name=response_desc.full_name,
-                        encoding="protobuf",
-                        data=self._fds_bytes,
-                    ),
-                ),
-            )
-            handler = functools.partial(
-                self._call,
-                base_path,
-                entity_id,
-                interface,
-                version,
-                procedure,
-                source_id,
-            )
-            services.append(Service(name=name, schema=schema, handler=handler))
-            names.append(name)
+            services = []
+            names = []
+            for procedure in keelson.interfaces.get_procedures(interface, version):
+                request_desc, response_desc = keelson.interfaces.get_procedure_schemas(
+                    interface, version, procedure
+                )
+                name = (
+                    f"{base_path}/{entity_id}/{interface}/{version}"
+                    f"/{procedure}/{source_id}"
+                )
+                schema = ServiceSchema(
+                    name=name,
+                    request=self._message_schema(request_desc),
+                    response=self._message_schema(response_desc),
+                )
+                handler = functools.partial(
+                    self._call,
+                    base_path,
+                    entity_id,
+                    interface,
+                    version,
+                    procedure,
+                    source_id,
+                )
+                services.append(Service(name=name, schema=schema, handler=handler))
+                names.append(name)
 
-        self._server.add_services(services)
-        self._services[token_key] = names
+            self._server.add_services(services)
+            self._services[token_key] = names
+
         logger.info(
             "Advertised %d Foxglove services for %s/%s/%s/%s",
             len(names),
@@ -189,34 +222,50 @@ class RpcServiceBridge:
         source_id: str,
         request: ServiceRequest,
     ) -> bytes:
-        response = keelson.interfaces.invoke_procedure(
-            self._session,
-            base_path,
-            entity_id,
-            interface,
-            version,
-            procedure,
-            source_id,
-            request=bytes(request.payload),
-            timeout=10.0,
+        """Raw single-reply RPC passthrough (no payload decode/re-encode).
+
+        Mirrors keelson.interfaces.invoke_procedure minus the response
+        decode: the reply bytes go back to the Foxglove client unchanged,
+        so both protobuf and raw-JSON-string procedures round-trip intact.
+        A raised exception's string is what the Foxglove client sees.
+        """
+        key = keelson.construct_rpc_key(
+            base_path, entity_id, interface, version, procedure, source_id
         )
-        return response.SerializeToString()
+
+        for reply in self._session.get(
+            key, payload=bytes(request.payload), timeout=self._call_timeout
+        ):
+            if reply.ok is not None:
+                return reply.ok.payload.to_bytes()
+            err = ErrorResponse()
+            try:
+                err.ParseFromString(reply.err.payload.to_bytes())
+            except Exception:
+                raise RuntimeError("UNSPECIFIED: <undecodable ErrorResponse>") from None
+            raise RuntimeError(
+                f"{ErrorResponse.Code.Name(err.code)}: {err.error_description}"
+            )
+
+        raise TimeoutError(f"No reply on {key} within {self._call_timeout}s")
 
     def on_leave(self, token_key: str) -> None:
-        names = self._services.pop(token_key, None)
-        if not names:
-            return
-        self._server.remove_services(names)
+        with self._lock:
+            names = self._services.pop(token_key, None)
+            if not names:
+                return
+            self._server.remove_services(names)
         logger.info("Removed %d Foxglove services for %s", len(names), token_key)
 
     def close(self) -> None:
         """Undeclare/remove every outstanding Foxglove service."""
-        all_names = []
-        for names in self._services.values():
-            all_names.extend(names)
-        self._services.clear()
-        if all_names:
-            self._server.remove_services(all_names)
+        with self._lock:
+            all_names = []
+            for names in self._services.values():
+                all_names.extend(names)
+            self._services.clear()
+            if all_names:
+                self._server.remove_services(all_names)
 
 
 def run(session: zenoh.Session, args: argparse.Namespace):
@@ -244,7 +293,9 @@ def run(session: zenoh.Session, args: argparse.Namespace):
     rpc_bridge = None
     rpc_monitors: list = []
     if args.expose_rpc_services:
-        rpc_bridge = RpcServiceBridge(session, server)
+        rpc_bridge = RpcServiceBridge(
+            session, server, call_timeout=args.rpc_call_timeout
+        )
         for base_path in args.expose_rpc_services:
             pattern = f"{base_path}/@v0/*/@rpc/**"
             logger.info("Monitoring RPC liveliness on: %s", pattern)
@@ -429,6 +480,15 @@ if __name__ == "__main__":
         action="append",
         default=None,
         help="Advertise all live keelson RPC endpoints under this base path as Foxglove services",
+    )
+
+    parser.add_argument(
+        "--rpc-call-timeout",
+        type=float,
+        default=10.0,
+        help="Timeout (seconds) for RPC calls made on behalf of Foxglove clients. "
+        "Each call blocks one Foxglove handler thread for up to this long if the "
+        "responder is dead, so keep it as low as your slowest procedure allows.",
     )
 
     # Parse arguments and start doing our thing

--- a/connectors/foxglove/bin/keelson2foxglove.py
+++ b/connectors/foxglove/bin/keelson2foxglove.py
@@ -4,18 +4,24 @@ import sys
 import pathlib
 import logging
 import argparse
+import functools
 from typing import Dict
 from queue import Queue, Empty
 from threading import Thread
 
 import zenoh
 import keelson
+import keelson.interfaces
 import foxglove
 from foxglove import Channel, Schema
 from foxglove.websocket import (
     Capability,
     ChannelView,
     Client,
+    MessageSchema,
+    Service,
+    ServiceRequest,
+    ServiceSchema,
     ServerListener,
 )
 from google.protobuf.message import DecodeError
@@ -26,6 +32,7 @@ from keelson.scaffolding import (
     suppress_exception,
     check_queue_backpressure,
     GracefulShutdown,
+    LivelinessMonitor,
 )
 
 logger = logging.getLogger("foxglove-liveview")
@@ -67,21 +74,189 @@ class KeelsonListener(ServerListener):
             del self.subscribers[client.id]
 
 
+class RpcServiceBridge:
+    """Advertises live keelson RPC endpoints as callable Foxglove services.
+
+    Discovery is liveliness-driven: an interface-level liveliness token
+    joining/leaving the bus adds/removes the corresponding set of Foxglove
+    services. Only interfaces registered in this SDK's ``interfaces.yaml``
+    can be advertised (unknown interfaces are skipped with a warning).
+
+    Note: service handlers run ``invoke_procedure`` synchronously
+    (blocking up to ``timeout``) on the foxglove server's own handler
+    thread. This is acceptable for v1 and matches keelson's single-reply
+    RPC semantics; a slow/unresponsive responder will hold up that one
+    handler thread but not the rest of the bridge.
+    """
+
+    def __init__(self, session: zenoh.Session, server: foxglove.WebSocketServer):
+        self._session = session
+        self._server = server
+        self._fds_bytes = keelson.interfaces.get_interfaces_file_descriptor_set()
+        # token_key -> list of Foxglove service names advertised for it
+        self._services: Dict[str, list] = {}
+
+    def on_join(self, token_key: str) -> None:
+        # Guard against a rejoin after a transient reconnect re-declaring
+        # the same liveliness token — treat it as a no-op.
+        if token_key in self._services:
+            return
+
+        try:
+            parsed = keelson.parse_rpc_interface_liveliness_key(token_key)
+        except ValueError:
+            logger.debug(
+                "Liveliness key %s did not match the RPC interface pattern; ignoring",
+                token_key,
+            )
+            return
+
+        base_path = parsed["base_path"]
+        entity_id = parsed["entity_id"]
+        interface = parsed["interface"]
+        version = parsed["version"]
+        source_id = parsed["source_id"]
+
+        if not keelson.is_interface_well_known(f"{interface}/{version}"):
+            logger.warning(
+                "Live interface %s/%s (entity=%s, source=%s) is not in this "
+                "SDK's interfaces.yaml — skipping",
+                interface,
+                version,
+                entity_id,
+                source_id,
+            )
+            # Record an empty entry so we don't re-warn on rejoin.
+            self._services[token_key] = []
+            return
+
+        services = []
+        names = []
+        for procedure in keelson.interfaces.get_procedures(interface, version):
+            request_desc, response_desc = keelson.interfaces.get_procedure_schemas(
+                interface, version, procedure
+            )
+            name = f"{entity_id}/{interface}/{version}/{procedure}/{source_id}"
+            schema = ServiceSchema(
+                name=name,
+                request=MessageSchema(
+                    encoding="protobuf",
+                    schema=Schema(
+                        name=request_desc.full_name,
+                        encoding="protobuf",
+                        data=self._fds_bytes,
+                    ),
+                ),
+                response=MessageSchema(
+                    encoding="protobuf",
+                    schema=Schema(
+                        name=response_desc.full_name,
+                        encoding="protobuf",
+                        data=self._fds_bytes,
+                    ),
+                ),
+            )
+            handler = functools.partial(
+                self._call,
+                base_path,
+                entity_id,
+                interface,
+                version,
+                procedure,
+                source_id,
+            )
+            services.append(Service(name=name, schema=schema, handler=handler))
+            names.append(name)
+
+        self._server.add_services(services)
+        self._services[token_key] = names
+        logger.info(
+            "Advertised %d Foxglove services for %s/%s/%s/%s",
+            len(names),
+            entity_id,
+            interface,
+            version,
+            source_id,
+        )
+
+    def _call(
+        self,
+        base_path: str,
+        entity_id: str,
+        interface: str,
+        version: str,
+        procedure: str,
+        source_id: str,
+        request: ServiceRequest,
+    ) -> bytes:
+        response = keelson.interfaces.invoke_procedure(
+            self._session,
+            base_path,
+            entity_id,
+            interface,
+            version,
+            procedure,
+            source_id,
+            request=bytes(request.payload),
+            timeout=10.0,
+        )
+        return response.SerializeToString()
+
+    def on_leave(self, token_key: str) -> None:
+        names = self._services.pop(token_key, None)
+        if not names:
+            return
+        self._server.remove_services(names)
+        logger.info("Removed %d Foxglove services for %s", len(names), token_key)
+
+    def close(self) -> None:
+        """Undeclare/remove every outstanding Foxglove service."""
+        all_names = []
+        for names in self._services.values():
+            all_names.extend(names)
+        self._services.clear()
+        if all_names:
+            self._server.remove_services(all_names)
+
+
 def run(session: zenoh.Session, args: argparse.Namespace):
 
     logger.info("Starting ws server on %s:%s", args.ws_host, args.ws_port)
 
     listener = KeelsonListener()
 
+    capabilities = [Capability.ClientPublish]
+    if args.expose_rpc_services:
+        capabilities.append(Capability.Services)
+
     server = foxglove.start_server(
         host=args.ws_host,
         port=args.ws_port,
         server_listener=listener,
-        capabilities=[Capability.ClientPublish],
+        capabilities=capabilities,
         supported_encodings=["protobuf"],
     )
 
     queue = Queue()
+
+    # Wired up only when --expose-rpc-services is passed; everything below
+    # is a no-op otherwise so existing behavior is untouched.
+    rpc_bridge = None
+    rpc_monitors: list = []
+    if args.expose_rpc_services:
+        rpc_bridge = RpcServiceBridge(session, server)
+        for base_path in args.expose_rpc_services:
+            pattern = f"{base_path}/@v0/*/@rpc/**"
+            logger.info("Monitoring RPC liveliness on: %s", pattern)
+            rpc_monitors.append(
+                LivelinessMonitor(
+                    session,
+                    pattern,
+                    on_join=rpc_bridge.on_join,
+                    on_leave=rpc_bridge.on_leave,
+                    history=True,
+                )
+            )
 
     with GracefulShutdown() as shutdown:
 
@@ -201,6 +376,14 @@ def run(session: zenoh.Session, args: argparse.Namespace):
         if ws_publisher_thread.is_alive():
             logger.warning("ws publisher thread did not exit within 5s; abandoning")
 
+        if rpc_monitors:
+            logger.debug("Closing RPC liveliness monitors...")
+            for monitor in rpc_monitors:
+                monitor.close()
+        if rpc_bridge is not None:
+            logger.debug("Closing RPC service bridge...")
+            rpc_bridge.close()
+
         logger.debug("Stopping websocket server...")
         server.stop()
 
@@ -238,6 +421,14 @@ if __name__ == "__main__":
         type=_parse_pair,
         action="append",
         help="Add additional well-known subjects and protobuf types as --extra-subjects-types=path/to/subjects.yaml,path_to_protobuf_file_descriptor_set.bin",
+    )
+
+    parser.add_argument(
+        "--expose-rpc-services",
+        type=str,
+        action="append",
+        default=None,
+        help="Advertise all live keelson RPC endpoints under this base path as Foxglove services",
     )
 
     # Parse arguments and start doing our thing

--- a/connectors/foxglove/tests/test_foxglove_cli.py
+++ b/connectors/foxglove/tests/test_foxglove_cli.py
@@ -10,6 +10,7 @@ class TestFoxgloveCli:
         assert result.returncode == 0
         # The script should show help output
         assert "keelson" in result.stdout.lower() or "foxglove" in result.stdout.lower()
+        assert "--expose-rpc-services" in result.stdout
 
     def test_shows_usage(self, run_connector):
         """Test that running without arguments shows usage."""

--- a/connectors/foxglove/tests/test_foxglove_e2e.py
+++ b/connectors/foxglove/tests/test_foxglove_e2e.py
@@ -8,6 +8,11 @@ import socket
 import time
 
 import pytest
+import zenoh
+
+from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
+from keelson.interfaces.ReplayControl_pb2 import ReplaySuccessResponse
+from keelson.scaffolding import RpcOp, serve_rpc
 
 
 @pytest.mark.e2e
@@ -115,3 +120,70 @@ def test_foxglove_liveview_with_zenoh_data(connector_process_factory, zenoh_endp
     radar.stop()
 
     assert connected, "WebSocket should be accessible while receiving Zenoh data"
+
+
+@pytest.mark.e2e
+def test_foxglove_liveview_advertises_rpc_services(
+    connector_process_factory, zenoh_endpoints
+):
+    """foxglove-liveview started with --expose-rpc-services should discover
+    a live replay_control/v1 responder via interface-level liveliness and
+    log that it advertised Foxglove services for it."""
+    port = 18768
+    realm = "test-realm"
+
+    def _set_speed(op: RpcOp):
+        op.reply_ok(ReplaySuccessResponse())
+
+    def _seek(op: RpcOp):
+        op.reply_err("no file loaded", ErrorResponse.Code.INVALID_STATE)
+
+    conf = zenoh.Config()
+    conf.insert_json5("mode", '"peer"')
+    conf.insert_json5("listen/endpoints", f'["{zenoh_endpoints["listen"]}"]')
+
+    with zenoh.open(conf) as session:
+        serve_rpc(
+            session,
+            base_path=realm,
+            entity_id="test-vessel",
+            responder_id="mcap/0",
+            interface="replay_control",
+            version="v1",
+            handlers={"set_speed": _set_speed, "seek": _seek},
+        )
+        # Give the queryable + liveliness token declarations a moment to
+        # settle before the bridge process starts monitoring.
+        time.sleep(0.5)
+
+        server = connector_process_factory(
+            "foxglove",
+            "foxglove-liveview",
+            [
+                "--key",
+                "test/**",
+                "--ws-host",
+                "127.0.0.1",
+                "--ws-port",
+                str(port),
+                "--mode",
+                "peer",
+                "--connect",
+                zenoh_endpoints["connect"],
+                "--expose-rpc-services",
+                realm,
+            ],
+        )
+        server.start()
+        # Generous sleep for: server startup, liveliness history query,
+        # on_join dispatch, and service advertisement. CI is slow.
+        time.sleep(6.0)
+
+        assert server.is_running(), "foxglove-liveview should still be running"
+        server.stop()
+
+        _stdout, stderr = server.logs()
+        assert "Advertised" in stderr and "replay_control" in stderr, (
+            "Expected an 'Advertised N Foxglove services for ...' log line "
+            f"mentioning replay_control. stderr: {stderr[-4000:]}"
+        )

--- a/connectors/foxglove/tests/test_foxglove_e2e.py
+++ b/connectors/foxglove/tests/test_foxglove_e2e.py
@@ -4,15 +4,33 @@ End-to-end tests for the Foxglove connector.
 Tests the foxglove-liveview WebSocket server functionality.
 """
 
+import importlib.util
+import pathlib
 import socket
+import sys
 import time
+from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import zenoh
 
+import keelson
 from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
-from keelson.interfaces.ReplayControl_pb2 import ReplaySuccessResponse
+from keelson.interfaces.ReplayControl_pb2 import ReplaySuccessResponse, SetSpeedRequest
 from keelson.scaffolding import RpcOp, serve_rpc
+
+# Import the connector script dynamically so RpcServiceBridge can be
+# exercised in-process against a real zenoh session.
+BIN_ROOT = pathlib.Path(__file__).resolve().parent.parent / "bin"
+sys.path.insert(0, str(BIN_ROOT))
+_loader = SourceFileLoader(
+    "keelson2foxglove_e2e", str(BIN_ROOT / "keelson2foxglove.py")
+)
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+keelson2foxglove = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(keelson2foxglove)
 
 
 @pytest.mark.e2e
@@ -187,3 +205,75 @@ def test_foxglove_liveview_advertises_rpc_services(
             "Expected an 'Advertised N Foxglove services for ...' log line "
             f"mentioning replay_control. stderr: {stderr[-4000:]}"
         )
+
+
+@pytest.mark.e2e
+def test_rpc_service_bridge_call_path_round_trip():
+    """The Foxglove-handler → zenoh RPC call path, over a real zenoh
+    session: on_join builds handlers whose invocation reaches a real
+    serve_rpc responder, and the raw reply bytes come back unchanged."""
+    realm = "test-bridge-call-realm"
+    entity = "test-vessel"
+    responder = "mcap/0"
+
+    seen = {}
+
+    def _set_speed(op: RpcOp):
+        request = SetSpeedRequest()
+        request.ParseFromString(op.request_bytes)
+        seen["speed"] = request.speed
+        op.reply_ok(ReplaySuccessResponse())
+
+    def _seek(op: RpcOp):
+        op.reply_err("no file loaded", ErrorResponse.Code.INVALID_STATE)
+
+    conf = zenoh.Config()
+    conf.insert_json5("mode", '"peer"')
+
+    with zenoh.open(conf) as session:
+        serve_rpc(
+            session,
+            base_path=realm,
+            entity_id=entity,
+            responder_id=responder,
+            interface="replay_control",
+            version="v1",
+            handlers={"set_speed": _set_speed, "seek": _seek},
+        )
+        # Give the queryable declarations a moment to settle.
+        time.sleep(0.5)
+
+        mock_server = Mock()
+        bridge = keelson2foxglove.RpcServiceBridge(
+            session, mock_server, call_timeout=5.0
+        )
+        token_key = keelson.construct_rpc_interface_liveliness_key(
+            realm, entity, "replay_control", "v1", responder
+        )
+        bridge.on_join(token_key)
+
+        mock_server.add_services.assert_called_once()
+        (services,), _ = mock_server.add_services.call_args
+        services_by_name = {service.name: service for service in services}
+
+        # OK path: invoke the bound set_speed handler with a fake
+        # ServiceRequest; the returned bytes must parse as the responder's
+        # ReplaySuccessResponse.
+        set_speed = services_by_name[
+            f"{realm}/{entity}/replay_control/v1/set_speed/{responder}"
+        ]
+        fake_request = SimpleNamespace(
+            payload=SetSpeedRequest(speed=2.5).SerializeToString()
+        )
+        response_bytes = set_speed.handler(fake_request)
+        response = ReplaySuccessResponse()
+        response.ParseFromString(response_bytes)  # must not raise
+        assert seen["speed"] == pytest.approx(2.5)
+
+        # Error path: the responder's reply_err surfaces as a raised
+        # exception whose message carries the typed code.
+        seek = services_by_name[f"{realm}/{entity}/replay_control/v1/seek/{responder}"]
+        with pytest.raises(Exception, match="INVALID_STATE: no file loaded"):
+            seek.handler(SimpleNamespace(payload=b""))
+
+        bridge.close()

--- a/connectors/foxglove/tests/test_rpc_services_unit.py
+++ b/connectors/foxglove/tests/test_rpc_services_unit.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+
+"""Unit tests for RpcServiceBridge in keelson2foxglove.py.
+
+Exercises the liveliness-driven discovery of keelson RPC endpoints and
+their advertisement as Foxglove services, against Mock server/session
+objects (no real Zenoh or Foxglove server involved).
+"""
+
+import importlib.util
+import pathlib
+import sys
+from importlib.machinery import SourceFileLoader
+from unittest.mock import Mock
+
+import pytest
+
+from keelson.interfaces import RpcError, get_procedure_schemas, get_procedures
+from keelson.interfaces.ReplayControl_pb2 import ReplaySuccessResponse
+
+# Path to the bin root
+BIN_ROOT = pathlib.Path(__file__).resolve().parent.parent / "bin"
+sys.path.insert(0, str(BIN_ROOT))
+
+# Import the script dynamically
+_script_path = BIN_ROOT / "keelson2foxglove.py"
+_loader = SourceFileLoader("keelson2foxglove", str(_script_path))
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+keelson2foxglove = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(keelson2foxglove)
+
+RpcServiceBridge = keelson2foxglove.RpcServiceBridge
+
+REPLAY_CONTROL_TOKEN_KEY = "realm/@v0/boat/@rpc/replay_control/v1/*/mcap/0"
+UNKNOWN_INTERFACE_TOKEN_KEY = "realm/@v0/boat/@rpc/custom_iface/v1/*/x/0"
+
+REPLAY_CONTROL_PROCEDURES = get_procedures("replay_control", "v1")
+
+
+@pytest.fixture
+def mock_server():
+    server = Mock()
+    server.add_services = Mock()
+    server.remove_services = Mock()
+    return server
+
+
+@pytest.fixture
+def mock_session():
+    return Mock()
+
+
+@pytest.fixture
+def bridge(mock_session, mock_server):
+    return RpcServiceBridge(mock_session, mock_server)
+
+
+class TestOnJoin:
+    def test_adds_one_service_per_procedure(self, bridge, mock_server):
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+
+        mock_server.add_services.assert_called_once()
+        (services_arg,), _ = mock_server.add_services.call_args
+        assert len(services_arg) == len(REPLAY_CONTROL_PROCEDURES)
+
+        expected_names = {
+            f"boat/replay_control/v1/{procedure}/mcap/0"
+            for procedure in REPLAY_CONTROL_PROCEDURES
+        }
+        actual_names = {service.name for service in services_arg}
+        assert actual_names == expected_names
+
+    def test_service_schemas_match_procedure_schemas(self, bridge, mock_server):
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+
+        (services_arg,), _ = mock_server.add_services.call_args
+        services_by_name = {service.name: service for service in services_arg}
+
+        for procedure in REPLAY_CONTROL_PROCEDURES:
+            name = f"boat/replay_control/v1/{procedure}/mcap/0"
+            service = services_by_name[name]
+            request_desc, response_desc = get_procedure_schemas(
+                "replay_control", "v1", procedure
+            )
+            assert service.schema.name == name
+            assert service.schema.request.schema.name == request_desc.full_name
+            assert service.schema.response.schema.name == response_desc.full_name
+            assert service.schema.request.encoding == "protobuf"
+            assert service.schema.response.encoding == "protobuf"
+
+    def test_duplicate_on_join_is_a_no_op(self, bridge, mock_server):
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+
+        mock_server.add_services.assert_called_once()
+
+    def test_unknown_interface_warns_and_adds_nothing(
+        self, bridge, mock_server, caplog
+    ):
+        with caplog.at_level("WARNING"):
+            bridge.on_join(UNKNOWN_INTERFACE_TOKEN_KEY)
+
+        mock_server.add_services.assert_not_called()
+        assert len(caplog.records) == 1
+        assert "not in this SDK's interfaces.yaml" in caplog.records[0].message
+
+    def test_unknown_interface_does_not_re_warn_on_rejoin(
+        self, bridge, mock_server, caplog
+    ):
+        with caplog.at_level("WARNING"):
+            bridge.on_join(UNKNOWN_INTERFACE_TOKEN_KEY)
+            bridge.on_join(UNKNOWN_INTERFACE_TOKEN_KEY)
+
+        mock_server.add_services.assert_not_called()
+        assert len(caplog.records) == 1
+
+    def test_unparseable_key_is_ignored(self, bridge, mock_server, caplog):
+        with caplog.at_level("DEBUG"):
+            bridge.on_join("not-a-valid-liveliness-key")
+
+        mock_server.add_services.assert_not_called()
+        assert "not-a-valid-liveliness-key" not in bridge._services
+
+
+class TestOnLeave:
+    def test_removes_exactly_the_added_names(self, bridge, mock_server):
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+        (services_arg,), _ = mock_server.add_services.call_args
+        added_names = {service.name for service in services_arg}
+
+        bridge.on_leave(REPLAY_CONTROL_TOKEN_KEY)
+
+        mock_server.remove_services.assert_called_once()
+        (removed_names,), _ = mock_server.remove_services.call_args
+        assert set(removed_names) == added_names
+        assert REPLAY_CONTROL_TOKEN_KEY not in bridge._services
+
+    def test_leave_without_join_is_a_no_op(self, bridge, mock_server):
+        bridge.on_leave("some/unknown/token/key")
+        mock_server.remove_services.assert_not_called()
+
+    def test_leave_for_unknown_interface_entry_is_a_no_op(self, bridge, mock_server):
+        bridge.on_join(UNKNOWN_INTERFACE_TOKEN_KEY)
+        bridge.on_leave(UNKNOWN_INTERFACE_TOKEN_KEY)
+        mock_server.remove_services.assert_not_called()
+
+
+class TestCall:
+    def test_round_trip_returns_serialized_response(self, bridge, monkeypatch):
+        expected = ReplaySuccessResponse()
+        invoke_mock = Mock(return_value=expected)
+        monkeypatch.setattr(
+            keelson2foxglove.keelson.interfaces, "invoke_procedure", invoke_mock
+        )
+
+        request = Mock()
+        request.payload = b"\x01\x02\x03"
+
+        result = bridge._call(
+            "realm", "boat", "replay_control", "v1", "set_speed", "mcap/0", request
+        )
+
+        assert result == expected.SerializeToString()
+        invoke_mock.assert_called_once_with(
+            bridge._session,
+            "realm",
+            "boat",
+            "replay_control",
+            "v1",
+            "set_speed",
+            "mcap/0",
+            request=b"\x01\x02\x03",
+            timeout=10.0,
+        )
+
+    def test_propagates_rpc_error(self, bridge, monkeypatch):
+        invoke_mock = Mock(side_effect=RpcError(1, "INVALID_STATE", "boom"))
+        monkeypatch.setattr(
+            keelson2foxglove.keelson.interfaces, "invoke_procedure", invoke_mock
+        )
+
+        request = Mock()
+        request.payload = b""
+
+        with pytest.raises(RpcError):
+            bridge._call(
+                "realm", "boat", "replay_control", "v1", "seek", "mcap/0", request
+            )
+
+
+class TestClose:
+    def test_removes_everything(self, bridge, mock_server):
+        bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
+        mock_server.add_services.reset_mock()
+
+        bridge.close()
+
+        mock_server.remove_services.assert_called_once()
+        (removed_names,), _ = mock_server.remove_services.call_args
+        assert len(removed_names) == len(REPLAY_CONTROL_PROCEDURES)
+        assert bridge._services == {}
+
+    def test_close_with_nothing_advertised_is_a_no_op(self, bridge, mock_server):
+        bridge.close()
+        mock_server.remove_services.assert_not_called()

--- a/connectors/foxglove/tests/test_rpc_services_unit.py
+++ b/connectors/foxglove/tests/test_rpc_services_unit.py
@@ -15,7 +15,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from keelson.interfaces import RpcError, get_procedure_schemas, get_procedures
+from keelson.interfaces import get_procedure_schemas, get_procedures
+from keelson.interfaces.ErrorResponse_pb2 import ErrorResponse
 from keelson.interfaces.ReplayControl_pb2 import ReplaySuccessResponse
 
 # Path to the bin root
@@ -32,9 +33,27 @@ _spec.loader.exec_module(keelson2foxglove)
 RpcServiceBridge = keelson2foxglove.RpcServiceBridge
 
 REPLAY_CONTROL_TOKEN_KEY = "realm/@v0/boat/@rpc/replay_control/v1/*/mcap/0"
+CONFIGURABLE_TOKEN_KEY = "realm/@v0/boat/@rpc/configurable/v1/*/cfg/0"
 UNKNOWN_INTERFACE_TOKEN_KEY = "realm/@v0/boat/@rpc/custom_iface/v1/*/x/0"
 
 REPLAY_CONTROL_PROCEDURES = get_procedures("replay_control", "v1")
+
+
+def _make_ok_reply(payload_bytes: bytes):
+    reply = Mock()
+    reply.ok.payload.to_bytes = Mock(return_value=payload_bytes)
+    return reply
+
+
+def _make_err_reply(code: int, description: str):
+    reply = Mock()
+    reply.ok = None
+    reply.err.payload.to_bytes = Mock(
+        return_value=ErrorResponse(
+            code=code, error_description=description
+        ).SerializeToString()
+    )
+    return reply
 
 
 @pytest.fixture
@@ -64,7 +83,7 @@ class TestOnJoin:
         assert len(services_arg) == len(REPLAY_CONTROL_PROCEDURES)
 
         expected_names = {
-            f"boat/replay_control/v1/{procedure}/mcap/0"
+            f"realm/boat/replay_control/v1/{procedure}/mcap/0"
             for procedure in REPLAY_CONTROL_PROCEDURES
         }
         actual_names = {service.name for service in services_arg}
@@ -77,7 +96,7 @@ class TestOnJoin:
         services_by_name = {service.name: service for service in services_arg}
 
         for procedure in REPLAY_CONTROL_PROCEDURES:
-            name = f"boat/replay_control/v1/{procedure}/mcap/0"
+            name = f"realm/boat/replay_control/v1/{procedure}/mcap/0"
             service = services_by_name[name]
             request_desc, response_desc = get_procedure_schemas(
                 "replay_control", "v1", procedure
@@ -87,6 +106,53 @@ class TestOnJoin:
             assert service.schema.response.schema.name == response_desc.full_name
             assert service.schema.request.encoding == "protobuf"
             assert service.schema.response.encoding == "protobuf"
+
+    def test_json_placeholder_sides_advertised_as_json(self, bridge, mock_server):
+        """configurable/v1's JSON{} placeholder sides (set_config request,
+        get_config response) must be advertised as json/jsonschema; the
+        genuinely-protobuf sides stay protobuf."""
+        bridge.on_join(CONFIGURABLE_TOKEN_KEY)
+
+        (services_arg,), _ = mock_server.add_services.call_args
+        services_by_name = {service.name: service for service in services_arg}
+
+        get_config = services_by_name["realm/boat/configurable/v1/get_config/cfg/0"]
+        set_config = services_by_name["realm/boat/configurable/v1/set_config/cfg/0"]
+
+        # JSON placeholder sides
+        assert get_config.schema.response.encoding == "json"
+        assert get_config.schema.response.schema.encoding == "jsonschema"
+        assert set_config.schema.request.encoding == "json"
+        assert set_config.schema.request.schema.encoding == "jsonschema"
+
+        # Protobuf sides remain protobuf
+        assert get_config.schema.request.encoding == "protobuf"
+        assert set_config.schema.response.encoding == "protobuf"
+
+    def test_two_base_paths_produce_distinct_names(self, bridge, mock_server):
+        """The same entity/interface/source under two base paths must not
+        collide: distinct service names, independently removable."""
+        token_a = "realm-a/@v0/boat/@rpc/replay_control/v1/*/mcap/0"
+        token_b = "realm-b/@v0/boat/@rpc/replay_control/v1/*/mcap/0"
+
+        bridge.on_join(token_a)
+        bridge.on_join(token_b)
+
+        assert mock_server.add_services.call_count == 2
+        (services_a,), _ = mock_server.add_services.call_args_list[0]
+        (services_b,), _ = mock_server.add_services.call_args_list[1]
+        names_a = {service.name for service in services_a}
+        names_b = {service.name for service in services_b}
+        assert names_a.isdisjoint(names_b)
+        assert all(name.startswith("realm-a/") for name in names_a)
+        assert all(name.startswith("realm-b/") for name in names_b)
+
+        # Leaving one realm removes only that realm's services.
+        bridge.on_leave(token_a)
+        mock_server.remove_services.assert_called_once()
+        (removed,), _ = mock_server.remove_services.call_args
+        assert set(removed) == names_a
+        assert token_b in bridge._services
 
     def test_duplicate_on_join_is_a_no_op(self, bridge, mock_server):
         bridge.on_join(REPLAY_CONTROL_TOKEN_KEY)
@@ -146,12 +212,9 @@ class TestOnLeave:
 
 
 class TestCall:
-    def test_round_trip_returns_serialized_response(self, bridge, monkeypatch):
-        expected = ReplaySuccessResponse()
-        invoke_mock = Mock(return_value=expected)
-        monkeypatch.setattr(
-            keelson2foxglove.keelson.interfaces, "invoke_procedure", invoke_mock
-        )
+    def test_ok_reply_bytes_are_passed_through_unchanged(self, bridge, mock_session):
+        response_bytes = ReplaySuccessResponse().SerializeToString()
+        mock_session.get = Mock(return_value=iter([_make_ok_reply(response_bytes)]))
 
         request = Mock()
         request.payload = b"\x01\x02\x03"
@@ -160,32 +223,65 @@ class TestCall:
             "realm", "boat", "replay_control", "v1", "set_speed", "mcap/0", request
         )
 
-        assert result == expected.SerializeToString()
-        invoke_mock.assert_called_once_with(
-            bridge._session,
-            "realm",
-            "boat",
-            "replay_control",
-            "v1",
-            "set_speed",
-            "mcap/0",
-            request=b"\x01\x02\x03",
+        assert result == response_bytes
+        mock_session.get.assert_called_once_with(
+            "realm/@v0/boat/@rpc/replay_control/v1/set_speed/mcap/0",
+            payload=b"\x01\x02\x03",
             timeout=10.0,
         )
 
-    def test_propagates_rpc_error(self, bridge, monkeypatch):
-        invoke_mock = Mock(side_effect=RpcError(1, "INVALID_STATE", "boom"))
-        monkeypatch.setattr(
-            keelson2foxglove.keelson.interfaces, "invoke_procedure", invoke_mock
+    def test_json_payloads_are_passed_through_raw(self, bridge, mock_session):
+        """A raw-JSON procedure (configurable/v1) must round-trip its bytes
+        with no protobuf decode attempt — this is what invoke_procedure
+        could not do."""
+        raw_json = b'{"speed_limit_kn": 12}'
+        mock_session.get = Mock(return_value=iter([_make_ok_reply(raw_json)]))
+
+        request = Mock()
+        request.payload = b"{}"
+
+        result = bridge._call(
+            "realm", "boat", "configurable", "v1", "get_config", "cfg/0", request
+        )
+
+        assert result == raw_json
+
+    def test_err_reply_raises_with_code_and_description(self, bridge, mock_session):
+        mock_session.get = Mock(
+            return_value=iter(
+                [_make_err_reply(ErrorResponse.Code.INVALID_STATE, "no file loaded")]
+            )
         )
 
         request = Mock()
         request.payload = b""
 
-        with pytest.raises(RpcError):
+        with pytest.raises(RuntimeError, match="INVALID_STATE: no file loaded"):
             bridge._call(
                 "realm", "boat", "replay_control", "v1", "seek", "mcap/0", request
             )
+
+    def test_no_reply_raises_timeout_naming_the_endpoint(self, bridge, mock_session):
+        mock_session.get = Mock(return_value=iter([]))
+
+        request = Mock()
+        request.payload = b""
+
+        with pytest.raises(TimeoutError, match="replay_control/v1/play/mcap/0"):
+            bridge._call(
+                "realm", "boat", "replay_control", "v1", "play", "mcap/0", request
+            )
+
+    def test_call_timeout_is_plumbed_through(self, mock_session, mock_server):
+        bridge = RpcServiceBridge(mock_session, mock_server, call_timeout=2.5)
+        mock_session.get = Mock(return_value=iter([_make_ok_reply(b"")]))
+
+        request = Mock()
+        request.payload = b""
+
+        bridge._call("realm", "boat", "replay_control", "v1", "play", "mcap/0", request)
+        _, kwargs = mock_session.get.call_args
+        assert kwargs["timeout"] == 2.5
 
 
 class TestClose:


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #169 — do not merge first.** This PR is based on `feature/discovery-and-typing-program` and only makes sense on top of it (it consumes the RPC discovery, interface registry and `invoke_procedure` surfaces introduced there). Merge #169, then retarget/rebase this onto `main`.

Makes `keelson2foxglove` the reference discovery client both RFCs called for: with `--expose-rpc-services BASE_PATH`, every live keelson RPC endpoint is advertised as a callable Foxglove service — discovered from interface-level liveliness, schema-resolved from the SDK's bundled FileDescriptorSet, with zero per-interface code. Foxglove Studio renders call panels for arm / set_mode / mission upload / replay control / configurable for whatever is actually alive on the bus; services appear on liveliness join and disappear on leave.

Details:
- Service names: `{base_path}/{entity}/{interface}/{version}/{procedure}/{source_id}` (realm-scoped, collision-free across multiple `--expose-rpc-services` values).
- Calls are a raw byte passthrough to the queryable — protobuf interfaces round-trip untouched; JSON-placeholder sides (`configurable/v1`) are advertised with `encoding="json"` so Studio presents a JSON input, and work end to end.
- `reply_err` surfaces as readable `CODE: description` errors in Studio; timeouts name the endpoint; `--rpc-call-timeout` (default 10 s).
- The bridge remains a pure consumer (declares no liveliness tokens).

Reviewed by a detailed second-pass review; both majors it found (JSON interfaces advertised-but-uncallable, cross-realm name collisions) are fixed in the second commit, including the e2e call-path integration test that would have caught the first one. 25 connector tests (20 unit + 5 e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRjuqo2uBoa6eqRUps22Ve
