### PR TITLE
Add AlarmAck interface: a route for acknowledging an alarm

### DIFF
--- a/interfaces/AlarmAck.proto
+++ b/interfaces/AlarmAck.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+// Acknowledging an alarm.
+//
+// `keelson.Alarm` (payloads/Alarm.proto) already models multi-user
+// acknowledgment — it carries `repeated AlarmAcknowledgment acknowledgers` and
+// an `acknowledged` flag — but there has been no route for an acknowledgment to
+// reach the alarm's owner. This interface is that route.
+//
+// WHY AN RPC AND NOT A PUBLISH. `alarm` is a pub/sub subject with no arbiter,
+// so acknowledging by republishing the alarm with oneself appended is a
+// read-modify-write against a value anyone may also be writing:
+//
+//   ROC-A reads  alarm{acknowledgers: []}
+//   ROC-B reads  alarm{acknowledgers: []}
+//   ROC-A writes alarm{acknowledgers: [A]}
+//   ROC-B writes alarm{acknowledgers: [B]}    <- A's acknowledgment is gone
+//   owner writes alarm{acknowledgers: []}     <- and now both are
+//
+// It would also mean a shore station writing to a key the vessel owns. Routing
+// acknowledgments through the owner keeps exactly one writer, which is the
+// only arrangement in which `acknowledgers` can be trusted.
+//
+// The responder is the entity that publishes the alarm. On receiving an
+// acknowledgment it appends to `acknowledgers`, sets `acknowledged`, and
+// republishes the alarm on its usual key — so every subscriber converges on
+// the same list without any of them writing to it.
+//
+// Transport-level failures (no responder, malformed request) surface as
+// ErrorResponse on the RPC error channel as usual; an acknowledgment the owner
+// declines for its own reasons is a successful call with `acknowledged` false
+// and a populated `reason`.
+
+message AcknowledgeAlarmRequest {
+  // Client wall-clock at send, so the responder can log round-trip latency.
+  google.protobuf.Timestamp timestamp = 1;
+
+  // `Alarm.identifier` of the alarm being acknowledged.
+  string identifier = 2;
+
+  // Who is acknowledging — operator or station id. Recorded verbatim in the
+  // alarm's `AlarmAcknowledgment.acknowledged_by`, so it should be meaningful
+  // to somebody reading the alarm later, not an opaque session id.
+  string acknowledged_by = 3;
+}
+
+message AcknowledgeAlarmResponse {
+  // True when the owner recorded the acknowledgment. False is a legitimate
+  // outcome, not an error: an alarm may have expired, may already have been
+  // acknowledged by this party, or may carry ACK_NONE.
+  bool acknowledged = 1;
+
+  // Why not, when `acknowledged` is false. Empty otherwise.
+  string reason = 2;
+
+  // When the owner recorded it. Set only when `acknowledged` is true.
+  google.protobuf.Timestamp timestamp_acknowledged = 3;
+}
+
+service AlarmAck {
+  rpc acknowledge_alarm(AcknowledgeAlarmRequest) returns (AcknowledgeAlarmResponse);
+}


### PR DESCRIPTION
Adds `interfaces/AlarmAck.proto` — an RPC for acknowledging a `keelson.Alarm`.

**The gap.** `keelson.Alarm` carries `acknowledged` and a repeated `acknowledgers` list, so the payload can *express* that an alarm was acknowledged and by whom. But there is **no route by which a station can cause that to happen**: no procedure, no interface. An operator's acknowledgement therefore stops at the local UI and no other station ever learns of it — precisely the divergence between two ROCs watching the same vessel that IEC 62923 alarm management exists to prevent.

This adds the missing half as an interface rather than a payload, because acknowledging is a request to the alarm's owner that can be **refused** — the owner decides whether the acknowledgement is accepted, and the requester needs to know which. A publish could not express refusal.

**Deliberately an interface, deliberately not a producer.** Nothing in this PR publishes alarms or serves this procedure. `alarm` is one of the subjects with no producer in the ecosystem, and its natural home is genuinely ambiguous — the subject spans SAFETY, NAVIGATION, TECHNICAL and FIRE_ALARM categories, which belong to different systems on a real vessel. Rather than guess a home and build the wrong producer, this lands the contract so that whoever does own alarms can serve it.

Consumer side: Crowsnest already decodes and displays `keelson.Alarm` (RISE-Maritime/crowsnest-dev#27) and is ready to call this once something answers it.

Implements the acknowledgement half of RISE-Maritime/crowsnest-dev#27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)