### PR TITLE
feat(messages): CommandAuthority / CommandRequest payloads

### DIFF
--- a/messages/payloads/CommandAuthority.proto
+++ b/messages/payloads/CommandAuthority.proto
@@ -24,15 +24,22 @@ package keelson;
 //     right to edit the voyage plan, and vice versa.
 //
 // LEASE SEMANTICS (identical to RouteEditAuthority, intentionally)
-//   - granted_at and expires_at bracket a lease_ttl_seconds window.
+//   - The lease lasts lease_ttl_seconds from each message a receiver accepts.
+//     Receivers arm that deadline on their OWN clock; the timestamp fields are
+//     the holder's view only. See protocol specification §6.5.1 — the rule is
+//     written once for the lease pattern, and it matters more here than for
+//     route editing, because the failure is two stations both believing they
+//     have the conn.
 //   - The holder refreshes every heartbeat_interval_seconds by republishing
 //     with a new expires_at and last_heartbeat.
 //   - On graceful release the holder publishes released=true, carrying the
 //     same token, which clears authority for all subscribers.
-//   - On crash or link loss the holder stops heartbeating and the lease lapses
-//     at expires_at, after which another station may claim it. Subscribers
-//     MUST treat lapse as loss of command and alarm accordingly: a stale
-//     authority message is not evidence that anyone still has the conn.
+//   - On crash or link loss the holder stops heartbeating and each subscriber
+//     lapses the lease lease_ttl_seconds after the last message IT heard,
+//     after which another station may claim it. Expiry follows silence, not a
+//     remote timestamp. Subscribers MUST treat lapse as loss of command and
+//     alarm accordingly: a stale authority message is not evidence that anyone
+//     still has the conn.
 //
 // A station wanting command publishes a CommandRequest to a sibling key. The
 // holder may prompt its operator and then either grant (see below) or ignore,
@@ -61,13 +68,28 @@ message CommandAuthority {
   // originates from the current holder.
   string token = 4;
 
-  // Lease window.
+  // Lease window, IN THE HOLDER'S CLOCK.
+  //
+  // The holder's own view of its lease: display, logging, diagnostics. A
+  // receiver MUST NOT decide expiry by comparing expires_at against its own
+  // clock (protocol specification §6.5.1).
   google.protobuf.Timestamp granted_at = 10;
   google.protobuf.Timestamp expires_at = 11;
   google.protobuf.Timestamp last_heartbeat = 12;
 
-  // Lease configuration echoed for transparency.
+  // THE LEASE CONTRACT. This is what receivers arm on: on every accepted
+  // message a receiver sets its deadline at (local receipt + lease_ttl_seconds)
+  // and lapses the lease when its own clock passes it.
+  //
+  // A duration is the only lease quantity that survives two sites disagreeing
+  // about what time it is. Comparing expires_at instead, a station running a
+  // few seconds fast lapses a live lease early and may take the conn while the
+  // current holder still believes it has it — both stations correct by their
+  // own clock, and nothing in the system detecting the overlap. For an
+  // interlock in front of actuation that is the failure that matters.
   uint32 lease_ttl_seconds = 13;
+
+  // The holder's refresh cadence. Informational.
   uint32 heartbeat_interval_seconds = 14;
 
   // Set true on graceful release. A released=true message MUST carry the same

--- a/messages/payloads/CommandAuthority.proto
+++ b/messages/payloads/CommandAuthority.proto
@@ -1,0 +1,96 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+package keelson;
+
+// Single-writer command authority over a vessel.
+//
+// At most one site may command a given vessel at any time. This is the
+// interlock in front of actuation — arming, mode changes, setpoints — so that
+// two remote operation centres cannot both believe they have the conn.
+//
+// RELATIONSHIP TO OTHER TYPES
+//   - ROCStatus broadcasts MONITORING / CONTROLLING per entity. It is a
+//     statement of intent with no operator identity, no token and no TTL, so
+//     it cannot arbitrate between two claimants. It remains the right type for
+//     "what is this ROC doing"; it is not a lock.
+//   - OperationalAuthority describes whether a vessel will ACCEPT remote
+//     control (health, interlocks). That is the vessel's veto, and it composes
+//     with this message: a station can hold command and still be refused.
+//   - RouteEditAuthority is the same lease shape applied to route editing.
+//     The two are deliberately parallel — a reader who knows one knows the
+//     other — but they are separate locks: holding the conn does not grant the
+//     right to edit the voyage plan, and vice versa.
+//
+// LEASE SEMANTICS (identical to RouteEditAuthority, intentionally)
+//   - granted_at and expires_at bracket a lease_ttl_seconds window.
+//   - The holder refreshes every heartbeat_interval_seconds by republishing
+//     with a new expires_at and last_heartbeat.
+//   - On graceful release the holder publishes released=true, carrying the
+//     same token, which clears authority for all subscribers.
+//   - On crash or link loss the holder stops heartbeating and the lease lapses
+//     at expires_at, after which another station may claim it. Subscribers
+//     MUST treat lapse as loss of command and alarm accordingly: a stale
+//     authority message is not evidence that anyone still has the conn.
+//
+// A station wanting command publishes a CommandRequest to a sibling key. The
+// holder may prompt its operator and then either grant (see below) or ignore,
+// which the requester resolves as a timeout.
+//
+// GRANTING. A holder transfers command by publishing a CommandAuthority whose
+// controller_id names the REQUESTER, with a fresh token. Releasing instead
+// (released=true) merely frees the lease and races any other station that is
+// waiting, so it must not be used to hand over to a specific operator.
+
+message CommandAuthority {
+
+  // The vessel whose conn this message refers to. Naming is deliberately not
+  // "entity_id": authority is held over a vessel, while the Keelson entity in
+  // the key expression may be a connector or gateway acting for it.
+  string vessel_id = 1;
+
+  // Identity of the controlling operator+site, e.g. "ted@ROC-1".
+  string controller_id = 2;
+
+  // Free-form site label ("ROC-1", "vessel-bridge").
+  string controller_site = 3;
+
+  // Random token (16 random bytes, hex-encoded). Subscribers use the token to
+  // filter out their own publications and to validate that a release
+  // originates from the current holder.
+  string token = 4;
+
+  // Lease window.
+  google.protobuf.Timestamp granted_at = 10;
+  google.protobuf.Timestamp expires_at = 11;
+  google.protobuf.Timestamp last_heartbeat = 12;
+
+  // Lease configuration echoed for transparency.
+  uint32 lease_ttl_seconds = 13;
+  uint32 heartbeat_interval_seconds = 14;
+
+  // Set true on graceful release. A released=true message MUST carry the same
+  // token as the most recent grant for the receiver to accept it.
+  bool released = 20;
+}
+
+message CommandRequest {
+
+  string vessel_id = 1;
+
+  // Identity of the would-be commander.
+  string requester_id = 2;
+  string requester_site = 3;
+
+  google.protobuf.Timestamp requested_at = 4;
+
+  // Human-readable reason ("watch handover", "bridge unresponsive", ...).
+  string reason = 5;
+
+  // Seizing command from a LIVE holder is deliberately not expressible. There
+  // is no force flag: an unresponsive holder is recovered by lease expiry,
+  // which bounds the takeover delay at lease_ttl_seconds and leaves the former
+  // holder able to observe that it lost the conn. A force override would let
+  // one station silently displace another mid-manoeuvre.
+}

--- a/messages/subjects.yaml
+++ b/messages/subjects.yaml
@@ -286,3 +286,12 @@ wave_height_mean_m:                     keelson.TimestampedFloatPeriod
 # Externally-authored products (bundled, carry provenance + a validity window)
 weather_alert:                          keelson.WeatherAlert
 weather_forecast:                       keelson.WeatherForecast
+
+# Command authority — who currently has the conn
+# A single-writer lease, parallel in shape to the route_edit_authority lease
+# that arrives with PR #141, but a SEPARATE lock: holding the conn does not
+# grant the right to edit the voyage plan. Distinct from roc_status (intent,
+# no lock) and operational_authority (the vessel's own veto on accepting
+# remote control) — see CommandAuthority.proto.
+command_authority:                      keelson.CommandAuthority
+command_request:                        keelson.CommandRequest


### PR DESCRIPTION
Adds a canonical single-writer lease for **vessel command authority** — who currently has the conn — as the interlock in front of actuation (arming, mode changes, setpoints), so two remote operation centres cannot both believe they hold it.

**Nothing in keelson could express this.** `ROCStatus` broadcasts a centre's *intent* (`MONITORING` / `CONTROLLING`) with no lock and no arbitration — two ROCs can both announce `CONTROLLING` and neither is wrong. `operational_authority` is the **vessel's** veto on accepting remote control, a different axis entirely. Neither is a mutual-exclusion primitive.

### Shape

Deliberately identical in shape to `RouteEditAuthority` — lease with holder, expiry and heartbeat — but a **separate lock**: holding the conn does not grant the right to edit the voyage plan, and the two are held by different people at different times in practice.

`CommandRequest` has **no `force` field**, unlike some lease designs. That is deliberate: a live holder can never be seized from. An unresponsive holder is recovered by lease expiry, which is a timeout the vessel can reason about, whereas a forced seizure is one station deciding unilaterally that another has stopped paying attention.

### Verified across two stations

Over the real Zenoh router: take → `typeName: keelson.CommandAuthority` carrying `vesselId`, lease held well past the 30 s TTL, the other station showing `HELD: ROC-A-operator@ROC-A`; request → holder-side prompt → directed grant moved authority to ROC-B; release returned both to `AVAILABLE`.

### Notes for review

- **Coupling to #141:** this lease was modelled on `RouteEditAuthority`. If the multi-subject / design feedback on that PR changes its shape, this should follow it rather than diverge — worth reviewing the two together.
- This branch previously carried a second commit adding `sdks/python/keelson/qos.yaml`. **Dropped**: that file is byte-identical to `messages/qos.yaml`, which has since landed on `main` at the correct path (`messages/` is the source of truth; the SDK directory holds generated copies). It has been rebased onto current main and force-pushed.
- Consumer side is implemented in Crowsnest and blocked only on a keelson-js release carrying these types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)