### PR TITLE
ci: make dev a first-class integration branch, guard prereleases

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -4,7 +4,7 @@ Two workflow files: `ci.yml` (continuous integration) and `release.yml` (publish
 
 ## CI Pipeline (ci.yml)
 
-Triggers: push to main, all pull requests.
+Triggers: push to main or dev, all pull requests.
 
 ```
 lint ──────────────┬── test-sdk [matrix: 3.11, 3.12, 3.13]
@@ -48,7 +48,19 @@ Triggers: GitHub release published.
 | **python-sdk** | Build wheel, publish to PyPI via `pypa/gh-action-pypi-publish` |
 | **javascript-sdk** | `npm publish --provenance --access public` (tag `next` for prereleases) |
 | **docker** | Multi-platform build (linux/amd64), push to `ghcr.io/rise-maritime/keelson` |
-| **docs** | `mkdocs gh-deploy --force` to GitHub Pages |
+| **docs** | `mkdocs gh-deploy --force` to GitHub Pages (stable releases only) |
+
+### Prereleases
+
+Prereleases are cut from `dev`, stable releases from `main`. Marking the GitHub
+release as a prerelease changes three jobs:
+
+- **javascript-sdk** publishes under the `next` dist-tag instead of `latest`
+- **docker** pushes only `:<tag_name>`, leaving `:latest` on the last stable release
+- **docs** is skipped entirely
+
+**python-sdk** is unguarded on purpose: a PEP 440 version (`0.6.0rc1`) is already a
+prerelease to pip, so it is not installed without `--pre` or an exact pin.
 
 ## Adding a New Connector to CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
+        name: Compute image tags
+        id: image_tags
+        run: |
+          # The version tag is always pushed — deployments pin to it. `:latest`
+          # only moves for a stable release: a prerelease cut from `dev` must not
+          # become what an unpinned `docker pull keelson` resolves to.
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/rise-maritime/keelson:${{ github.event.release.tag_name }}"
+            if [ "${{ github.event.release.prerelease }}" != "true" ]; then
+              echo "ghcr.io/rise-maritime/keelson:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6
@@ -108,14 +123,16 @@ jobs:
           file: docker/Dockerfile
           push: true
           platforms: linux/amd64
-          tags: |
-            ghcr.io/rise-maritime/keelson:latest
-            ghcr.io/rise-maritime/keelson:${{ github.event.release.tag_name }}
+          tags: ${{ steps.image_tags.outputs.tags }}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
   docs:
+    # The published docs site tracks stable releases only. A prerelease cut from
+    # `dev` would otherwise gh-deploy unreviewed protocol docs over it.
+    if: github.event.release.prerelease == false
+
     permissions:
       contents: write
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,17 @@ docker build -f docker/Dockerfile -t keelson .
 
 ## Git Workflow
 
-- Branches: feature -> dev -> main
-- Version tracked in `sdks/python/pyproject.toml` and `sdks/js/package.json` (currently `0.5.0`)
+- Branches: feature -> dev -> main. `dev` is the integration branch: feature PRs
+  target it, conflicts between them are resolved on the feature branch, and the
+  batch is promoted to `main` with a single `dev -> main` PR.
+- After anything lands on `main` (a release, a hotfix), merge `main` back into `dev`.
+  A branch merged only one way drifts.
+- Prereleases are cut from `dev`, stable releases from `main`. See
+  `.github/CLAUDE.md` for what the prerelease flag changes.
+- Version tracked in `sdks/python/pyproject.toml` and `sdks/js/package.json`. The two
+  use different syntax for the same prerelease — PEP 440 `0.6.0rc1` for Python,
+  semver `0.6.0-rc.1` for npm — and must be bumped in lockstep, followed by
+  `uv lock` and the `uv export` in Dependency Management (CI fails on drift).
 
 ## Zenoh Key Format
 


### PR DESCRIPTION
Groundwork for integrating the eight open PRs on `dev` rather than serialising them into `main`.

`origin/dev` now exists (branched from `main`). The old local `dev` was 237 commits behind with nothing on it; `CLAUDE.md` has described a `feature -> dev -> main` workflow for a while without the middle step existing.

### What changes

**`ci.yml`** — runs on pushes to `dev` as well as `main`, so the post-merge state of the integration branch is tested. `pull_request:` is unfiltered, so PRs retargeted to `dev` were already covered; this only adds the post-merge run.

**`release.yml`** — two jobs would have damaged production the first time a prerelease was cut from `dev`:

| Job | Before | After |
|---|---|---|
| `docker` | pushed `:latest` unconditionally | `:latest` only on a stable release; `:<tag_name>` still always pushed |
| `docs` | `mkdocs gh-deploy --force` unconditionally | skipped on prereleases |

`python-sdk` is deliberately left unguarded — `0.6.0rc1` is a PEP 440 prerelease, so pip will not resolve it without `--pre` or an exact pin. `javascript-sdk` was already correct via `--tag next`.

Docs updated in `CLAUDE.md` and `.github/CLAUDE.md`.

### Follow-up (not in this PR)

PRs #169, #141, #173, #176, #175, #174, #172 and #171 get retargeted to `dev` and merged there, then `0.6.0-pre.1` is cut from `dev` so crowsnest and the connector repos can develop against it. #134 stays on `main` until it is rebased — it is 89 commits behind.

### Verification

Both workflows parse. The `:latest` guard is verifiable after the first prerelease: `ghcr.io/rise-maritime/keelson:latest` must still resolve to the `0.5.4` digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)