### PR TITLE
fix(release): derive the published version from the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,62 @@ permissions:
 
 jobs:
 
-  python-sdk:
+  # The release tag is the single source of truth for the published version.
+  #
+  # It did not used to be: this workflow published whatever version happened to
+  # be committed in sdks/js/package.json and sdks/python/pyproject.toml, and the
+  # README asked a human to remember to bump them first. Release 0.5.4 was
+  # tagged with those files still reading 0.5.3, so both registries rejected it
+  # as a duplicate and the release shipped no SDKs at all — while `docs` and
+  # `docker` succeeded, so it looked like a normal release. Deriving the version
+  # here makes the tag and the artifact incapable of disagreeing.
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve version from release tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"   # tolerate a v-prefix; current tags have none
+          if [ -z "$VERSION" ]; then
+            echo "::error::Release tag is empty — cannot determine a version to publish."
+            exit 1
+          fi
+          echo "Publishing as version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  python-sdk:
+    needs: version
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
     steps:
 
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v7
+
+      # `--frozen` matters: plain `uv version` writes the file and then tries to
+      # re-lock and sync, which exits non-zero here and would fail the job even
+      # though the version was set correctly.
+      - name: Set version from release tag
+        run: cd sdks/python && uv version --frozen "${VERSION}"
+
+      # Read the version back rather than reusing $VERSION, because PEP 440
+      # normalises it: a tag of 0.5.9-rc.2 becomes 0.5.9rc2 here while npm keeps
+      # the semver spelling. Guarding on the un-normalised string would miss an
+      # already-published prerelease.
+      - name: Refuse to republish an existing version
+        run: |
+          PKG_VERSION="$(cd sdks/python && uv version --short)"
+          echo "PyPI version: ${PKG_VERSION}"
+          if curl -fsSL -o /dev/null "https://pypi.org/pypi/keelson/${PKG_VERSION}/json"; then
+            echo "::error::keelson ${PKG_VERSION} is already on PyPI. Tag a new version."
+            exit 1
+          fi
 
       - name: Sync workspace
         run: uv sync --group dev
@@ -35,7 +84,10 @@ jobs:
           packages-dir: sdks/python/dist/
 
   javascript-sdk:
+    needs: version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
     steps:
 
       - uses: actions/checkout@v4
@@ -50,11 +102,23 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
+      # Same reasoning as the PyPI guard: this is exactly how 0.5.4 failed, and
+      # `npm publish` only says so as its final act.
+      - name: Refuse to republish an existing version
+        run: |
+          if npm view "@rise-maritime/keelson-js@${VERSION}" version >/dev/null 2>&1; then
+            echo "::error::@rise-maritime/keelson-js ${VERSION} is already on npm. Tag a new version."
+            exit 1
+          fi
+
       - name: Sync for protoc
         run: uv sync --group dev
 
       - name: Install JS dependencies
         run: cd sdks/js && npm ci
+
+      - name: Set version from release tag
+        run: cd sdks/js && npm version --no-git-tag-version --allow-same-version "${VERSION}"
 
       - name: Generate code
         run: cd sdks/js && ./generate_javascript.sh
@@ -73,7 +137,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docker:
+    needs: version
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
     steps:
       -
         name: Checkout
@@ -83,6 +150,11 @@ jobs:
       -
         name: Sync for protoc
         run: uv sync --group dev
+      -
+        # The image `pip install`s sdks/python, so without this a :0.5.5 image
+        # reports keelson 0.5.3 from inside. Same lie, different artifact.
+        name: Set version from release tag
+        run: cd sdks/python && uv version --frozen "${VERSION}"
       -
         name: Generate SDK code
         run: cd sdks/python && ./generate_python.sh

--- a/README.md
+++ b/README.md
@@ -113,10 +113,23 @@ Built using [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/). F
 
 ### How to Make a New Release
 
-Make sure to do the following:
+- Make a new release on Github, tagged with the version number (e.g. `0.5.5`,
+  or `0.5.5-rc.1` marked as a pre-release).
 
-- Update version numbers in the respective SDKs
-- Make a new release on Github with name according to version number
+That is the whole procedure. **Do not hand-edit the version in the SDKs** — the
+release workflow sets it from the tag, so the tag and the published artifacts
+cannot disagree.
+
+It used to say "update version numbers in the respective SDKs" first, and that
+step is exactly what went wrong: release `0.5.4` was tagged with the SDK files
+still reading `0.5.3`, both registries rejected the duplicate, and the release
+shipped no SDKs at all. `docs` and `docker` succeeded, so the release page
+looked normal while `npm i @rise-maritime/keelson-js@0.5.4` returned 404.
+
+Note that a pre-release tag publishes npm under the `next` dist-tag, leaves
+`docker :latest` alone and skips the docs deploy; a stable tag does all three.
+The two registries spell prereleases differently by convention — a `0.5.5-rc.1`
+tag publishes as `0.5.5-rc.1` on npm and `0.5.5rc1` on PyPI (PEP 440).
 
 ### Contribute to Keelson
 

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rise-maritime/keelson-js",
+  "//version": "NOT the published version. The release workflow overwrites it from the release tag (npm version --no-git-tag-version), so tag and artifact cannot disagree. Only matters for local installs; do not hand-bump before tagging — that manual step is what broke release 0.5.4.",
   "version": "0.5.3",
   "description": "Keelson JavaScript SDK with Node-RED nodes",
   "main": "dist/index.js",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,5 +1,9 @@
 [project]
 name = "keelson"
+# NOT the published version. The release workflow overwrites this from the
+# release tag (`uv version --frozen`), so the tag and the artifact cannot
+# disagree. This value only matters for local installs; do not hand-bump it
+# before tagging — that manual step is what broke release 0.5.4.
 version = "0.5.3"
 description = "A Python Software Development Kit for Keelson"
 readme = "README.md"


### PR DESCRIPTION
## The 0.5.4 release shipped no SDKs

`0.5.4` is marked **Latest** on the releases page. It does not exist on either registry:

```
$ npm view @rise-maritime/keelson-js@0.5.4 version
npm error 404 No match found for version 0.5.4
```

[Run 27747774530](https://github.com/RISE-Maritime/keelson/actions/runs/27747774530) — `docs` ✅ `docker` ✅ `javascript-sdk` ❌ `python-sdk` ❌:

```
javascript-sdk  npm error You cannot publish over the previously published versions: 0.5.3.
python-sdk      HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
```

**Why.** The workflow has no version step — it checks out the tag and publishes whatever version is *committed* in `sdks/js/package.json` and `sdks/python/pyproject.toml`. The README asks a human to bump those first, and nothing enforces it. `0.5.4` was tagged with both files still reading `0.5.3`, so both registries rejected it as a duplicate. Because the two jobs that *do* publish are the two that failed, the release looks normal.

**This is not a one-off waiting on a re-run.** `main` still reads `0.5.3` today, so the next release fails identically.

## The fix

The tag becomes the single source of truth. A `version` job resolves it (stripping any `v` prefix); each SDK job sets it before building:

| | |
|---|---|
| JS | `npm version --no-git-tag-version --allow-same-version "$VERSION"` |
| Python | `uv version --frozen "$VERSION"` |
| Docker | same as Python — the image `pip install`s `sdks/python`, so a `:0.5.5` image was reporting `keelson 0.5.3` from inside |

Tag and artifact can no longer disagree, and the manual README step is deleted rather than documented more loudly.

Each SDK job also refuses up front to republish an existing version, with a readable message. That case currently surfaces as a 400 buried a hundred log lines into the publish step — which is precisely how a failed release passed for a successful one.

## Two things only testing caught

I ran the version commands against copies of the real files rather than trusting them to read correctly:

1. **Plain `uv version` exits non-zero.** It writes the file and *then* re-locks and syncs, which fails here. In CI that fails the job even though the version was set correctly — swapping one release failure for another. Hence `--frozen` (verified exit 0, including inside the uv workspace, which behaves differently from a bare directory).
2. **PEP 440 normalises prereleases.** A `0.5.9-rc.2` tag becomes `0.5.9rc2` in `pyproject.toml`, while npm keeps the semver spelling. The PyPI guard therefore reads the version back with `uv version --short` instead of reusing the tag — otherwise it would miss an already-published prerelease and fall through to the same 400.

## Behaviour change worth knowing

Tag `0.5.4-pre.1` previously published npm `0.5.4-rc.1` — the tag and artifact names already diverged even when it worked. Afterwards, that tag publishes `0.5.4-pre.1`. **Already-published versions are untouched**, so existing pins (including Crowsnest's `0.5.4-rc.1`) are unaffected; prerelease names simply follow their tags from now on.

## Not addressed, deliberately

**The existing `0.5.4` release.** Re-releasing is a maintainer decision with outward effect, and that tag was cut from `main` before the route work — it contains no `Route`, `Voyage` or `CommandAuthority`. So anyone "upgrading to latest" today gets a 404, and would get a *regression* if it were published as-is. Flagging rather than acting.

Branched off `main` so it can merge independently of the five PRs in flight (#141, #172-#176).

*Verification: workflow YAML parses; version logic exercised against copies of both real files for `0.5.5`, `v0.5.5` and `0.5.5-rc.2`; `uv version --frozen` re-tested in place inside the workspace and the tree restored. The workflow itself only runs on a real release, so it cannot be exercised end-to-end before merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)